### PR TITLE
s/skip-ad/skipad

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -452,7 +452,7 @@ conforming IDL fragments, as described in the Web IDL specification. [[!WEBIDL]]
           playback has a notion of playlist.
         </li>
         <li>
-          <dfn enum-value for=MediaSessionAction>skip-ad</dfn>: the action
+          <dfn enum-value for=MediaSessionAction>skipad</dfn>: the action
           intent is to skip the advertisement that is currently playing.
         </li>
       </ul>
@@ -637,7 +637,7 @@ enum MediaSessionAction {
   "seekforward",
   "previoustrack",
   "nexttrack",
-  "skip-ad",
+  "skipad",
 };
 
 callback MediaSessionActionHandler = void();


### PR DESCRIPTION
To be consistent with other media session actions that do not use ["Dash case"](https://stackoverflow.com/questions/11273282/whats-the-name-for-hyphen-separated-case/12273101), let's rename the Skip Ad media session action to `skipad` that was introduced in https://github.com/WICG/mediasession/pull/203

R: @mounirlamouri


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/mediasession/pull/208.html" title="Last updated on Feb 4, 2019, 8:24 AM UTC (84d03b4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/mediasession/208/98d3eba...beaufortfrancois:84d03b4.html" title="Last updated on Feb 4, 2019, 8:24 AM UTC (84d03b4)">Diff</a>