### PR TITLE
Update spec info to point to Media WG

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing
+
+Contributions to this repository are intended to become part of Recommendation-track documents
+governed by the [W3C Patent Policy](http://www.w3.org/Consortium/Patent-Policy-20040205/) and
+[Software and Document License](http://www.w3.org/Consortium/Legal/copyright-software). To contribute, you must
+either participate in the relevant W3C Working Group or make a non-member patent licensing
+ commitment.
+
+If you are not the sole contributor to a contribution (pull request), please identify all
+contributors in the pull request's body or in subsequent comments.
+
+ To add a contributor (other than yourself, that's automatic), mark them one per line as follows:
+
+ ```
+ +@github_username
+ ```
+
+ If you added a contributor by mistake, you can remove them in a comment with:
+
+ ```
+ -@github_username
+ ```
+
+ If you are making a pull request on behalf of someone else but you had no part in designing the
+ feature, you can remove yourself with the above syntax.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,2 @@
+All documents in this Repository are licensed by contributors under the [W3C
+Software and Document License](http://www.w3.org/Consortium/Legal/copyright-software).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Media Session Standard
 
-https://wicg.github.io/mediasession/
+https://w3c.github.io/mediasession/
 
 This standardization project aims to add support for media keys and audio focus to the Web. Media keys, like play, pause, fast forward and rewind, are found on keyboards, headsets, remote controls, and on lock screens of mobile devices.
 
@@ -26,7 +26,7 @@ Update `index.bs` and send a Pull Request with your changes. When your Pull Requ
 
 To run Bikeshed locally, [install Bikeshed](https://github.com/tabatkins/bikeshed/blob/prespec/docs/install.md) and then run `bikeshed spec` in the working directory.
 
-Everyone is welcome to contribute! However, you need [join WICG](https://www.w3.org/community/wicg/) first and sign the [W3C Community Contributor License Agreement](https://www.w3.org/community/about/agreements/cla/).
+Everyone is welcome to contribute! See the [CONTRIBUTING.md](CONTRIBUTING.md) file for practical licensing details for contributions.
 
 ## Code of conduct
 

--- a/index.bs
+++ b/index.bs
@@ -1,24 +1,25 @@
 <pre class="metadata">
 Title: Media Session Standard
-Status: CG-DRAFT
-ED: https://wicg.github.io/mediasession
+Repository: w3c/mediasession
+Status: ED
+ED: https://w3c.github.io/mediasession
 Shortname: mediasession
 Level: 1
 Editor: Mounir Lamouri, Google Inc., mlamouri@google.com
 Former Editor: Zhiqiang Zhang, Google Inc., zqzhang@google.com
 Former Editor: Rich Tibbett, Opera, richt@opera.com
 
-Group: wicg
+Group: mediawg
 Logo: https://resources.whatwg.org/logo-mediasession.svg
 Abstract: This specification enables web developers to show customized media
 Abstract: metadata on platform UI, customize available platform media
 Abstract: controls, and access platform media keys such as hardware keys found
 Abstract: on keyboards, headsets, remote controls, and software keys found in
 Abstract: notification areas and on lock screens of mobile devices.
-!Participate: <a href="https://github.com/WICG/mediasession/">We are on GitHub</a>
-!Participate: <a href="https://github.com/WICG/mediasession/issues/new">File an issue</a>
-!Participate: <a href="https://github.com/WICG/mediasession/issues?state=open">Open issues</a>
-!Version History: <a href="https://github.com/WICG/mediasession/commits">https://github.com/WICG/mediasession/commits</a>
+!Participate: <a href="https://github.com/w3c/mediasession/">We are on GitHub</a>
+!Participate: <a href="https://github.com/w3c/mediasession/issues/new">File an issue</a>
+!Participate: <a href="https://github.com/w3c/mediasession/issues?state=open">Open issues</a>
+!Version History: <a href="https://github.com/w3c/mediasession/commits">https://github.com/w3c/mediasession/commits</a>
 Ignored Vars: context, media, session
 Boilerplate: omit conformance, omit feedback-header
 </pre>
@@ -452,16 +453,16 @@ conforming IDL fragments, as described in the Web IDL specification. [[!WEBIDL]]
           playback has a notion of playlist.
         </li>
         <li>
-          <dfn enum-value for=MediaSessionAction>skipad</dfn>: the action
-          intent is to skip the advertisement that is currently playing.
+          <dfn enum-value for=MediaSessionAction>skipad</dfn>: the action intent
+          is to skip the advertisement that is currently playing.
         </li>
         <li>
-          <dfn enum-value for=MediaSessionAction>stop</dfn>: the action intent is
-          to stop the playback and clear the state if appropriate.
+          <dfn enum-value for=MediaSessionAction>stop</dfn>: the action intent
+          is to stop the playback and clear the state if appropriate.
         </li>
-	<li>
-          <dfn enum-value for=MediaSessionAction>seekto</dfn>: the action intent is
-          to move the playback time to a specific time.
+        <li>
+          <dfn enum-value for=MediaSessionAction>seekto</dfn>: the action intent
+          is to move the playback time to a specific time.
         </li>
       </ul>
     </p>
@@ -520,22 +521,22 @@ conforming IDL fragments, as described in the Web IDL specification. [[!WEBIDL]]
           Let <var>handler</var> be the {{MediaSessionActionHandler}} associated
           with the key <var>action</var> in <var>actions</var>.
         </li>
-	<li>
-	  Run <var>handler</var> with the <var>details</var> parameter set to:
-	  <ul>
+        <li>
+          Run <var>handler</var> with the <var>details</var> parameter set to:
+          <ul>
             <li>
-	      {{MediaSessionSeekActionDetails}} if <var>action</var> is
-	      <a enum-value for=MediaSessionAction>seekbackward</a> or
+              {{MediaSessionSeekActionDetails}} if <var>action</var> is
+              <a enum-value for=MediaSessionAction>seekbackward</a> or
               <a enum-value for=MediaSessionAction>seekforward</a>.
-	    </li>
-	    <li>
-	      {{MediaSessionSeekToActionDetails}} if <var>action</var> is
-	      <a enum-value for=MediaSessionAction>seekto</a>.
-	    </li>
-	    <li>
+            </li>
+            <li>
+              {{MediaSessionSeekToActionDetails}} if <var>action</var> is
+              <a enum-value for=MediaSessionAction>seekto</a>.
+            </li>
+            <li>
               Otherwise, with {{MediaSessionActionDetails}}.
             </li>
-	  </ul>
+          </ul>
         </li>
       </ol>
     </p>
@@ -641,8 +642,10 @@ conforming IDL fragments, as described in the Web IDL specification. [[!WEBIDL]]
     <h3 id='position-state'>Position State</h3>
 
     <p>
-      A user agent MAY display the <a>current playback position</a> and <a>duration</a>
-      of a media session in the platform UI depending on platform conventions. The
+      A user agent MAY display the <a>current playback position</a> and
+      <a>duration</a>
+      of a media session in the platform UI depending on platform conventions.
+      The
       <dfn>position state</dfn> is the combination of the following:
       <ul>
         <li>
@@ -652,27 +655,29 @@ conforming IDL fragments, as described in the Web IDL specification. [[!WEBIDL]]
           The <dfn>playback rate</dfn> of the media. It is a coefficient.
         </li>
         <li>
-          The <dfn>last reported playback position</dfn> of the media. This is the
-          playback position of the media in seconds when the <a>position state</a>
+          The <dfn>last reported playback position</dfn> of the media. This is
+          the playback position of the media in seconds when the <a>position
+          state</a>
           was created.
         </li>
       </ul>
     </p>
 
     <p>
-      The <a>position state</a> is represented by a {{MediaPositionState}} which MUST
-      always be stored with the <dfn>last position updated time</dfn>. This is the
-      time the <a>position state</a> was last updated in seconds.
+      The <a>position state</a> is represented by a {{MediaPositionState}} which
+      MUST always be stored with the <dfn>last position updated time</dfn>. This
+      is the time the <a>position state</a> was last updated in seconds.
     </p>
 
     <p>
-      The RECOMMENDED way to determine the <a>position state</a> is to monitor the
-      media elements whose node document's browsing context is the
+      The RECOMMENDED way to determine the <a>position state</a> is to monitor
+      the media elements whose node document's browsing context is the
       <a>browsing context</a>.
     </p>
 
     <p>
-      The <dfn>actual playback rate</dfn> is a coefficient computed in the following way:
+      The <dfn>actual playback rate</dfn> is a coefficient computed in the
+      following way:
       <ul>
         <li>
           If the <a>actual playback state</a> is <a enum-value
@@ -685,8 +690,8 @@ conforming IDL fragments, as described in the Web IDL specification. [[!WEBIDL]]
     </p>
 
     <p>
-      The <dfn>current playback position</dfn> in seconds is computed in the following
-      way:
+      The <dfn>current playback position</dfn> in seconds is computed in the
+      following way:
       <ul>
         <li>
           Set <var>time elapsed</var> to the system time in seconds minus the
@@ -703,7 +708,8 @@ conforming IDL fragments, as described in the Web IDL specification. [[!WEBIDL]]
           If <var>position</var> is less than zero, return zero.
         </li>
         <li>
-          If <var>position</var> is greater than <a>duration</a>, return <a>duration</a>.
+          If <var>position</var> is greater than <a>duration</a>, return
+          <a>duration</a>.
         </li>
         <li>
           Return <var>position</var>.
@@ -847,8 +853,8 @@ interface MediaSession {
 </p>
 
 <p>
-  The <dfn method for=MediaSession>setPositionState()</dfn> method, when
-  invoked MUST perform the following steps:
+  The <dfn method for=MediaSession>setPositionState()</dfn> method, when invoked
+  MUST perform the following steps:
 
   <ul>
     <li>
@@ -859,9 +865,9 @@ interface MediaSession {
       throw a <a exception>TypeError</a>.
     </li>
     <li>
-      If the <a dict-member for="MediaPositionState">position</a> is negative
-      or greater than <a dict-member for="MediaPositionState">duration</a>,
-      throw a <a exception>TypeError</a>.
+      If the <a dict-member for="MediaPositionState">position</a> is negative or
+      greater than <a dict-member for="MediaPositionState">duration</a>, throw a
+      <a exception>TypeError</a>.
     </li>
     <li>
       If the <a dict-member for="MediaPositionState">playbackRate</a> is zero
@@ -1141,7 +1147,8 @@ used to specify the {{MediaImage}} object's <a>MIME type</a>. It is a hint as to
 the media type of the image. The purpose of this attribute is to allow a user
 agent to ignore images of media types it does not support.
 
-<h2 id="the-mediapositionstate-dictionary">The {{MediaPositionState}} dictionary</h2>
+<h2 id="the-mediapositionstate-dictionary">The {{MediaPositionState}}
+dictionary</h2>
 
 <pre class="idl">
 
@@ -1152,24 +1159,30 @@ dictionary MediaPositionState {
 };
 </pre>
 
-The {{MediaPositionState}} dictionary is a representation of the current playback
-position associated with a {{MediaSession}} that can be used by user agents to
-provide a user interface that displays the current playback position and duration.
+The {{MediaPositionState}} dictionary is a representation of the current
+playback position associated with a {{MediaSession}} that can be used by user
+agents to provide a user interface that displays the current playback position
+and duration.
 
-The <dfn dict-member for="MediaPositionState">duration</dfn> <a>dictionary member</a>
+The <dfn dict-member for="MediaPositionState">duration</dfn> <a>dictionary
+member</a>
 is used to specify the <a>duration</a> in seconds. It should always be positive
-and positive infinity can be used to indicate media without a defined end such as
-live playback.
+and positive infinity can be used to indicate media without a defined end such
+as live playback.
 
-The <dfn dict-member for="MediaPositionState">playbackRate</dfn> <a>dictionary member</a>
-is used to specify the <a>playback rate</a>. It can be positive to represent forward
-playback or negative to represent backwards playback. It should not be zero.
+The <dfn dict-member for="MediaPositionState">playbackRate</dfn> <a>dictionary
+member</a>
+is used to specify the <a>playback rate</a>. It can be positive to represent
+forward playback or negative to represent backwards playback. It should not be
+zero.
 
-The <dfn dict-member for="MediaPositionState">position</dfn> <a>dictionary member</a>
-is used to specify the <a>last reported playback position</a> in seconds. It should
-always be positive.
+The <dfn dict-member for="MediaPositionState">position</dfn> <a>dictionary
+member</a>
+is used to specify the <a>last reported playback position</a> in seconds. It
+should always be positive.
 
-<h2 id="the-mediasessionactiondetails-dictionary">The {{MediaSessionActionDetails}} dictionary</h2>
+<h2 id="the-mediasessionactiondetails-dictionary">The
+{{MediaSessionActionDetails}} dictionary</h2>
 
 <pre class="idl">
 
@@ -1187,24 +1200,29 @@ dictionary MediaSessionSeekToActionDetails : MediaSessionActionDetails {
 };
 </pre>
 
-The {{MediaSessionActionHandler}} MUST be run with the <var>details</var> parameter
-which is represented by a dictionary inherited from {{MediaSessionActionDetails}}.
+The {{MediaSessionActionHandler}} MUST be run with the <var>details</var>
+parameter which is represented by a dictionary inherited from
+{{MediaSessionActionDetails}}.
 
-The <dfn dict-member for="MediaSessionActionDetails">action</dfn> <a>dictionary member</a>
-is used to specify the <a>action</a> that the {{MediaSessionActionHandler}} is associated
-with.
+The <dfn dict-member for="MediaSessionActionDetails">action</dfn> <a>dictionary
+member</a>
+is used to specify the <a>action</a> that the {{MediaSessionActionHandler}} is
+associated with.
 
-The <dfn dict-member for="MediaSessionSeekActionDetails">seekOffset</dfn> <a>dictionary
-member</a> MAY be provided and is the time in seconds to move the playback time by. If
-it is not provided then the site should choose a sensible time (e.g. a few seconds).
+The <dfn dict-member for="MediaSessionSeekActionDetails">seekOffset</dfn>
+<a>dictionary member</a> MAY be provided and is the time in seconds to move the
+playback time by. If it is not provided then the site should choose a sensible
+time (e.g. a few seconds).
 
-The <dfn dict-member for="MediaSessionSeekToActionDetails">seekTime</dfn> <a>dictionary
-member</a> MUST be provided and is the time in seconds to move the playback time to.
+The <dfn dict-member for="MediaSessionSeekToActionDetails">seekTime</dfn>
+<a>dictionary member</a> MUST be provided and is the time in seconds to move the
+playback time to.
 
-The <dfn dict-member for="MediaSessionSeekToActionDetails">fastSeek</dfn> <a>dictionary
-member</a> MAY be provided and will be true if the
-<a enum-value for=MediaSessionAction>seekto</a> <a>action</a> is being called multiple
-times as part of a sequence and this is not the last call in that sequence.
+The <dfn dict-member for="MediaSessionSeekToActionDetails">fastSeek</dfn>
+<a>dictionary member</a> MAY be provided and will be true if the
+<a enum-value for=MediaSessionAction>seekto</a> <a>action</a> is being called
+multiple times as part of a sequence and this is not the last call in that
+sequence.
 
 <h2 id="examples">Examples</h2>
 

--- a/security-privacy-questionnaire.md
+++ b/security-privacy-questionnaire.md
@@ -84,7 +84,7 @@ third-party contexts but allows the user agent to disable the feature for third-
 
 The specification does not normative requirements for incognito mode but offers
 recommendations with regards to user's privacy in the [Security and Privacy
-Considerations section](https://wicg.github.io/mediasession/index.html#security-privacy-considerations).
+Considerations section](https://w3c.github.io/mediasession/index.html#security-privacy-considerations).
 
 **Does this specification persist data to a user’s local device?**
 

--- a/w3c.json
+++ b/w3c.json
@@ -1,7 +1,5 @@
 {
-  "group": [
-    "115198"
-  ],
+  "group": 115198,
   "contacts": [
     "tidoust",
     "jernoble",

--- a/w3c.json
+++ b/w3c.json
@@ -1,0 +1,11 @@
+{
+  "group": [
+    "115198"
+  ],
+  "contacts": [
+    "tidoust",
+    "jernoble",
+    "mounirlamouri"
+  ],
+  "repo-type": "rec-track"
+}


### PR DESCRIPTION
- Update spec boilerplate (copyright, SOTD) to note Media WG ownership
- Update self-references from `wicg.github.io` to `w3c.github.io`
- Add `w3c.json`, contributing and license files

Note the PR depends on https://github.com/tabatkins/bikeshed/pull/1498
... and should only be merged once the repo has been transferred to the W3C organization (#220)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/mediasession/pull/222.html" title="Last updated on Jul 24, 2019, 2:35 PM UTC (772bbbf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/mediasession/222/7af65e5...tidoust:772bbbf.html" title="Last updated on Jul 24, 2019, 2:35 PM UTC (772bbbf)">Diff</a>