### PR TITLE
Make MediaSessionActionDetails members non-nullable

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1205,9 +1205,9 @@ should always be positive.
 
 dictionary MediaSessionActionDetails {
   required MediaSessionAction action;
-  double? seekOffset;
-  double? seekTime;
-  boolean? fastSeek;
+  double seekOffset;
+  double seekTime;
+  boolean fastSeek;
 };
 </pre>
 


### PR DESCRIPTION
They are optional and might therefore be unset even if not nullable. No
prose describes when they would be null so letting them be nullable
appears unnecessary.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/pull/226.html" title="Last updated on Aug 15, 2019, 3:12 AM UTC (70f0864)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/226/4b2f4eb...70f0864.html" title="Last updated on Aug 15, 2019, 3:12 AM UTC (70f0864)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/pull/226.html" title="Last updated on Sep 13, 2022, 7:59 AM UTC (a1e8c10)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/226/553bfab...a1e8c10.html" title="Last updated on Sep 13, 2022, 7:59 AM UTC (a1e8c10)">Diff</a>