### PR TITLE
Use new constructor() syntax

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -897,8 +897,9 @@ interface MediaSession {
 
 <pre class="idl">
 
-[Constructor(optional MediaMetadataInit init), Exposed=Window]
+[Exposed=Window]
 interface MediaMetadata {
+  constructor(optional MediaMetadataInit init);
   attribute DOMString title;
   attribute DOMString artist;
   attribute DOMString album;

--- a/index.bs
+++ b/index.bs
@@ -899,7 +899,7 @@ interface MediaSession {
 
 [Exposed=Window]
 interface MediaMetadata {
-  constructor(optional MediaMetadataInit init);
+  constructor(optional MediaMetadataInit init = {});
   attribute DOMString title;
   attribute DOMString artist;
   attribute DOMString album;


### PR DESCRIPTION
The constructor syntax of `MediaMetadata` interface should be updated to use the new constructor syntax (heycam/webidl#700). This solves https://github.com/w3c/mediasession/issues/235.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ChunMinChang/mediasession/pull/236.html" title="Last updated on Sep 19, 2019, 4:05 PM UTC (9e92f43)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/236/acd69f9...ChunMinChang:9e92f43.html" title="Last updated on Sep 19, 2019, 4:05 PM UTC (9e92f43)">Diff</a>