### PR TITLE
Fix fastSeek Web IDL type declaration

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1211,7 +1211,7 @@ dictionary MediaSessionSeekActionDetails : MediaSessionActionDetails {
 
 dictionary MediaSessionSeekToActionDetails : MediaSessionActionDetails {
   required double seekTime;
-  bool? fastSeek;
+  boolean? fastSeek;
 };
 </pre>
 


### PR DESCRIPTION
The boolean type is `boolean`, not `bool`, in Web IDL:
https://heycam.github.io/webidl/#idl-boolean


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/mediasession/pull/240.html" title="Last updated on Sep 27, 2019, 5:24 PM UTC (0266570)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/240/998ff76...tidoust:0266570.html" title="Last updated on Sep 27, 2019, 5:24 PM UTC (0266570)">Diff</a>