### PR TITLE
Make setPositionState() parameter syntax valid per WebIDL, fixes #231

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -758,7 +758,7 @@ interface MediaSession {
 
   void setActionHandler(MediaSessionAction action, MediaSessionActionHandler? handler);
 
-  void setPositionState(optional MediaPositionState? state);
+  void setPositionState(optional MediaPositionState state = {});
 };
 </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -859,8 +859,8 @@ interface MediaSession {
 
   <ul>
     <li>
-      If the <var>state</var> is a null or an empty dictionary then clear the
-      <a>position state</a>.
+      If the <var>state</var> is an empty dictionary then clear the <a>position
+      state</a>.
     </li>
     <li>
       If the <a dict-member for="MediaPositionState">duration</a> is not present


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/pull/242.html" title="Last updated on Oct 9, 2019, 12:44 AM UTC (82e07ef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/242/e675c56...82e07ef.html" title="Last updated on Oct 9, 2019, 12:44 AM UTC (82e07ef)">Diff</a>