### PR TITLE
Fix cross-spec links and references

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2,7 +2,7 @@
 Title: Media Session Standard
 Repository: w3c/mediasession
 Status: ED
-ED: https://w3c.github.io/mediasession
+ED: https://w3c.github.io/mediasession/
 Shortname: mediasession
 Level: 1
 Editor: Mounir Lamouri, w3cid 45389, Google Inc., mlamouri@google.com
@@ -51,64 +51,34 @@ table td, table th {
 <pre class="anchors">
 urlPrefix: https://html.spec.whatwg.org/multipage/; spec: HTML
     type: dfn
-        urlPrefix: infrastructure.html
-            text: case-sensitive; url: #case-sensitivity-and-string-comparison
-            text: ASCII case-insensitive; url: #ascii-case-insensitive
-            text: in parallel
+        urlPrefix: common-microsyntaxes.html
             text: unordered set of unique space-separated tokens; url: #unordered-set-of-unique-space-separated-tokens
-            text: document base url
-            text: MIME type
-        urlPrefix: embedded-content.html
+        urlPrefix: media.html
             text: media element
             text: muted; url: #concept-media-muted
-            text: pause event; url: #event-media-pause
-            text: play event; url: #event-media-play
             text: potentially playing
         urlPrefix: browsers.html
             text: browsing context
-            text: top-level browsing context
-            text: nested browsing context
         urlPrefix: webappapis.html
-            text: API base URL
             text: entry settings object
-            text: queue a task
-            text: task
-            text: task source
         urlPrefix: semantics.html
             text: link; for: HTMLLinkElement; url:#the-link-element
         urlPrefix: interaction.html
-            text: triggered by user activation
-    type: attribute
-        urlPrefix: semantics.html
-            text: sizes; for: HTMLLinkElement; url: #attr-link-sizes;
-urlPrefix: https://url.spec.whatwg.org/; spec: URL
-    type: dfn; urlPrefix: #concept-
-        text: url parser
-    type: dfn
-        text: absolute URL; url: #syntax-url-absolute
-        text: relative URL; url: #syntax-url-relative
+            text: activation notification
 urlPrefix: https://fetch.spec.whatwg.org/; spec: FETCH
     type: dfn; urlPrefix: #concept-
         text: fetch
-        text: request
-        text: context; url: request-context
-        text: context frame type; url: request-context-frame-type
         text: internal response
-        text: origin; url: request-origin
-        text: referrer; url: request-referrer
         text: response
         text: response type
-        text: url; url: request-url
     type: dfn;
         text: force Origin header flag
-urlPrefix: https://www.w3.org/TR/appmanifest/; spec: appmanifest
+urlPrefix: https://www.w3.org/TR/appmanifest/#dom-; spec: appmanifest
     type: dfn
-        text: image object; url: #dfn-image-object
-urlPrefix: https://heycam.github.io/webidl/
-    type: exception
-        text: TypeError
-urlPrefix: https://tc39.github.io/ecma262/#sec-object.; type: dfn
-    text: freeze
+        text: ImageResource
+urlPrefix: https://tc39.es/ecma262/#sec-object.; spec: WEBIDL;
+    type: dfn
+        text: freeze
 </pre>
 
 <h2 id="introduction">Introduction</h2>
@@ -504,7 +474,7 @@ conforming IDL fragments, as described in the Web IDL specification. [[!WEBIDL]]
       that a
       <a>media session action</a> named <var>action</var> has been triggered,
       the user agent MUST run the <dfn>handle media session action</dfn> steps
-      as follows and consider it <a>triggered by user activation</a>:
+      as follows:
       <ol>
         <li>
           If the <a>active media session</a> is <code>null</code>, abort these
@@ -538,6 +508,11 @@ conforming IDL fragments, as described in the Web IDL specification. [[!WEBIDL]]
               Otherwise, with {{MediaSessionActionDetails}}.
             </li>
           </ul>
+        </li>
+        <li>
+          Run the <a>activation notification</a> steps in the
+          <a>browsing context</a> associated with the
+          <a>active media session</a>.
         </li>
       </ol>
     </p>
@@ -848,13 +823,13 @@ interface MediaSession {
 </p>
 
 <p>
-  The <dfn method for=MediaSession>setActionHandler()</dfn> method, when
+  The <dfn method for=MediaSession>setActionHandler(action, handler)</dfn> method, when
   invoked, MUST run the <a>update action handler algorithm</a> with
   <var>action</var> and <var>handler</var> on the {{MediaSession}}.
 </p>
 
 <p>
-  The <dfn method for=MediaSession>setPositionState()</dfn> method, when invoked
+  The <dfn method for=MediaSession>setPositionState(state)</dfn> method, when invoked
   MUST perform the following steps:
 
   <ul>
@@ -1132,8 +1107,8 @@ dictionary MediaImage {
 };
 </pre>
 
-The {{MediaImage}} dictionary members are inspired by the <a lt="image
-object">image objects</a> in Web App Manifest.
+<p class="informative">The {{MediaImage}} dictionary members are inspired by
+<a>ImageResource</a> in [[AppManifest]].</p>
 
 The <dfn dict-member for="MediaImage">src</dfn> <a>dictionary member</a> is used
 to specify the {{MediaImage}} object's <dfn for="MediaImage">source</dfn>. It is
@@ -1221,8 +1196,8 @@ parameter which is represented by a dictionary inherited from
 
 The <dfn dict-member for="MediaSessionActionDetails">action</dfn> <a>dictionary
 member</a>
-is used to specify the <a>action</a> that the {{MediaSessionActionHandler}} is
-associated with.
+is used to specify the <a>media session action</a> that the
+{{MediaSessionActionHandler}} is associated with.
 
 The <dfn dict-member for="MediaSessionSeekActionDetails">seekOffset</dfn>
 <a>dictionary member</a> MAY be provided and is the time in seconds to move the
@@ -1235,9 +1210,9 @@ playback time to.
 
 The <dfn dict-member for="MediaSessionSeekToActionDetails">fastSeek</dfn>
 <a>dictionary member</a> MAY be provided and will be true if the
-<a enum-value for=MediaSessionAction>seekto</a> <a>action</a> is being called
-multiple times as part of a sequence and this is not the last call in that
-sequence.
+<a enum-value for=MediaSessionAction>seekto</a>
+<a lt="media session action">action</a> is being called multiple times as part
+of a sequence and this is not the last call in that sequence.
 
 <h2 id="examples">Examples</h2>
 


### PR DESCRIPTION
A few editorial updates to fix a few broken links and references:
- Drop custom dfns that are no longer needed (fixes a few outdated fragments and allows to see which additional dfns the spec needs on top of those that the referenced specs export)
- Replace "triggered by user activation" with new user activation model (see https://github.com/whatwg/html/issues/5129). This may warrant another iteration as I'm not clear whether we're supposed to call the "activation notification" steps
- Update definition of methods to fix IDL links
- Update reference to Web App Manifest and flag the paragraph as informative
- Fix links to "action"


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/mediasession/pull/247.html" title="Last updated on Jan 14, 2020, 6:25 PM UTC (20cef22)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/247/f9d7ca2...tidoust:20cef22.html" title="Last updated on Jan 14, 2020, 6:25 PM UTC (20cef22)">Diff</a>