### PR TITLE
Fix refs to ImageResource and string comparison

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -74,9 +74,6 @@ urlPrefix: https://fetch.spec.whatwg.org/; spec: FETCH
         text: response type
     type: dfn;
         text: force Origin header flag
-urlPrefix: https://www.w3.org/TR/appmanifest/#dom-; spec: appmanifest
-    type: dfn
-        text: ImageResource
 urlPrefix: https://tc39.es/ecma262/#sec-object.; spec: WEBIDL;
     type: dfn
         text: freeze
@@ -124,8 +121,7 @@ user agent must invoke its internal API for that attribute or method so that
 e.g. the author can't change the behavior by overriding attributes or methods
 with custom properties or functions in JavaScript.
 
-Unless otherwise stated, string comparisons are done in a <a>case-sensitive</a>
-manner.
+Unless otherwise stated, string comparisons use [=is|is identical to=].
 
 <h2 id="dependencies">Dependencies</h2>
 
@@ -1096,7 +1092,7 @@ dictionary MediaImage {
 </pre>
 
 <p class="informative">The {{MediaImage}} dictionary members are inspired by
-<a>ImageResource</a> in [[AppManifest]].</p>
+{{ImageResource}} in [[IMAGE-RESOURCE]].</p>
 
 The <dfn dict-member for="MediaImage">src</dfn> <a>dictionary member</a> is used
 to specify the {{MediaImage}} object's <dfn for="MediaImage">source</dfn>. It is


### PR DESCRIPTION
The `ImageResource` interface graduated to its own spec, and is no longer defined in AppManifest.

The notion of case-sensitivity is also no longer defined in HTML. The Infra spec defines string comparison more precisely through the "is" (or "is identical to") concept.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/mediasession/pull/260.html" title="Last updated on Dec 10, 2020, 10:46 AM UTC (014aac5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/260/5b5ecb5...tidoust:014aac5.html" title="Last updated on Dec 10, 2020, 10:46 AM UTC (014aac5)">Diff</a>