### PR TITLE
Drop non existing external script

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1492,5 +1492,3 @@ patience in working through the initial design issues; Jer Noble for his help in
 building a model that also works well within the iOS audio focus model; and
 Mounir Lamouri and Anton Vayvod for their early involvement, feedback and
 support in making this specification happen.
-
-<script id=head src=https://resources.whatwg.org/dfn.js></script>


### PR DESCRIPTION
The spec referenced a script on the WHATWG site which (no longer?) exists:
https://resources.whatwg.org/dfn.js

That script should be unnecessary in practice. It prevents the spec from being published to /TR, because external scripts are forbidden.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/pull/270.html" title="Last updated on May 4, 2021, 3:09 PM UTC (702a8c3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/270/98a8374...702a8c3.html" title="Last updated on May 4, 2021, 3:09 PM UTC (702a8c3)">Diff</a>