### PR TITLE
Add presenting slides actions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -444,6 +444,14 @@ conforming IDL fragments, as described in the Web IDL specification. [[!WEBIDL]]
           <dfn enum-value for=MediaSessionAction>hangup</dfn>: the action's intent
           is to end a call.
         </li>
+        <li>
+          <dfn enum-value for=MediaSessionAction>previousslide</dfn>: the action's intent
+          is to go back to the previous slide when presenting slides.
+        </li>
+        <li>
+          <dfn enum-value for=MediaSessionAction>nextslide</dfn>: the action's intent
+          is to go to the next slide when presenting slides.
+        </li>
       </ul>
     </p>
 
@@ -727,7 +735,9 @@ enum MediaSessionAction {
   "seekto",
   "togglemicrophone",
   "togglecamera",
-  "hangup"
+  "hangup",
+  "previousslide",
+  "nextslide"
 };
 
 callback MediaSessionActionHandler = undefined(MediaSessionActionDetails details);
@@ -885,12 +895,14 @@ interface MediaSession {
   the user agent whether the microphone and camera are currently considered by
   the page to be active (e.g. if the microphone is considered "muted" by the
   page since it is no longer sending audio through to a call, then the page can
-  invoke <code>setMicrophoneActive(false)</code>). The user agent MAY display UI
-  which invoke the handlers for the <a enum-value
-  for=MediaSessionAction>togglemicrophone</a> and <a enum-value
-  for=MediaSessionAction>togglecamera</a> <a>media session actions</a>, and
-  it is RECOMMENDED that the user agent respect the microphone and camera
+  invoke <code>setMicrophoneActive(false)</code>).
+  It is RECOMMENDED that the user agent respect the microphone and camera
   states indicated by the page in this UI.
+</p>
+
+<p>
+  The user agent MAY display UI which invokes handlers for
+  <a>media session actions</a>.
 </p>
 
 <h2 id="the-mediametadata-interface">The {{MediaMetadata}} interface</h2>
@@ -1474,6 +1486,23 @@ When the <a>media session action</a> is
 
     navigator.mediaSession.setActionHandler("hangup", function() {
       // End the call. Implementation omitted.
+    });
+  </pre>
+</div>
+
+<div class="example" id="example-presenting-slide-actions">
+  Handling presenting slide actions:
+  <pre class="lang-javascript">
+    var currentSlideIndex = 0;
+
+    navigator.mediaSession.setActionHandler("previousslide", function() {
+      currentSlideIndex--;
+      // Set current slide. Implementation omitted.
+    });
+
+    navigator.mediaSession.setActionHandler("nextslide", function() {
+      currentSlideIndex++;
+      // Set current slide. Implementation omitted.
     });
   </pre>
 </div>


### PR DESCRIPTION
This PR adds new presenting slides actions as discussed in https://github.com/w3c/mediasession/issues/274#issuecomment-1217121600

It does not add processing rules that allow them to be invoked from Capture Handle Actions yet.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/pull/284.html" title="Last updated on Aug 17, 2022, 6:34 AM UTC (a8d6a5a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/284/84b41c1...a8d6a5a.html" title="Last updated on Aug 17, 2022, 6:34 AM UTC (a8d6a5a)">Diff</a>