### PR TITLE
Introduce the possibility for a source to be tied to a specific media session

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -386,6 +386,15 @@ conforming IDL fragments, as described in the Web IDL specification. [[!WEBIDL]]
       Such a source can be the platform or the UI surfaces created by the user
       agent.
     </p>
+    <p>
+      A <a>media session action source</a> has an optional
+      <dfn for="media session action source">target</dfn> which should be the
+      recipient of any <a>media session action</a> created by the
+      <a>media session action source</a>. If a <a>media session action source</a>'s
+      <a for="media session action source">target</a> is <code>null</code>,
+      the <a>active media session</a> is the recipient of all
+      <a>media session action source</a>'s actions.
+    </p>
 
     <p>
       A <a>media session action</a> is represented by a {{MediaSessionAction}}
@@ -480,17 +489,24 @@ conforming IDL fragments, as described in the Web IDL specification. [[!WEBIDL]]
 
     <p>
       When the user agent is notified by a <a>media session action source</a>
-      that a
+      named <var>source</var> that a
       <a>media session action</a> named <var>action</var> has been triggered,
       the user agent MUST run the <dfn>handle media session action</dfn> steps
       as follows:
       <ol>
         <li>
-          If the <a>active media session</a> is <code>null</code>, abort these
-          steps.
+          Let <var>session</var> be <var>source</var>'s <a for="media session
+          action source">target</a>.
         </li>
         <li>
-          Let <var>actions</var> be the <a>active media session</a>'s
+          If <var>session</var> is <code>null</code>, set <var>session</var> to
+          the <a>active media session</a>.
+        </li>
+        <li>
+          If <var>session</var> is <code>null</code>, abort these steps.
+        </li>
+        <li>
+          Let <var>actions</var> be <var>session</var>'s
           <a>supported media session actions</a>.
         </li>
         <li>
@@ -507,8 +523,7 @@ conforming IDL fragments, as described in the Web IDL specification. [[!WEBIDL]]
         </li>
         <li>
           Run the <a>activation notification</a> steps in the
-          <a>browsing context</a> associated with the
-          <a>active media session</a>.
+          <a>browsing context</a> associated with <var>session</var>.
         </li>
       </ol>
     </p>


### PR DESCRIPTION
We call it the media session source target.
Make use of it when handling an action, and default to the active media session if the source does not have a target.

Fixes https://github.com/w3c/mediasession/issues/285


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediasession/pull/287.html" title="Last updated on Sep 19, 2022, 9:21 PM UTC (d3f67a6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/287/84b41c1...youennf:d3f67a6.html" title="Last updated on Sep 19, 2022, 9:21 PM UTC (d3f67a6)">Diff</a>