### PR TITLE
Remove redundant title attribute

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -381,8 +381,7 @@ conforming IDL fragments, as described in the Web IDL specification. [[!WEBIDL]]
     </p>
 
     <p>
-      A <dfn title='media session action source'>media session action
-      source</dfn> is a source that might produce a <a>media session action</a>.
+      A <dfn>media session action source</dfn> is a source that might produce a <a>media session action</a>.
       Such a source can be the platform or the UI surfaces created by the user
       agent.
     </p>


### PR DESCRIPTION
Remove redundant title attribute.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediasession/pull/289.html" title="Last updated on Sep 19, 2022, 9:32 PM UTC (aee498f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/289/84b41c1...youennf:aee498f.html" title="Last updated on Sep 19, 2022, 9:32 PM UTC (aee498f)">Diff</a>