### PR TITLE
Add enterpictureinpicture action

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1232,19 +1232,9 @@ should always be positive.
 
 dictionary MediaSessionActionDetails {
   required MediaSessionAction action;
-};
-
-dictionary MediaSessionSeekActionDetails : MediaSessionActionDetails {
   double seekOffset;
-};
-
-dictionary MediaSessionSeekToActionDetails : MediaSessionActionDetails {
   double seekTime;
   boolean fastSeek;
-};
-
-dictionary MediaSessionPictureInPictureActionDetails : MediaSessionActionDetails {
-  boolean automatic;
 };
 </pre>
 
@@ -1257,7 +1247,7 @@ member</a>
 is used to specify the <a>media session action</a> that the
 {{MediaSessionActionHandler}} is associated with.
 
-The <dfn dict-member for="MediaSessionSeekActionDetails">seekOffset</dfn>
+The <dfn dict-member for="MediaSessionActionDetails">seekOffset</dfn>
 <a>dictionary member</a> MAY be provided when the <a>media session action</a>
 is <a enum-value for=MediaSessionAction>seekbackward</a> or
 <a enum-value for=MediaSessionAction>seekforward</a>. It is the time in seconds
@@ -1269,25 +1259,18 @@ When the <a>media session action</a> is
 
 <ul>
   <li>
-    The <dfn dict-member for="MediaSessionSeekToActionDetails">seekTime</dfn>
+    The <dfn dict-member for="MediaSessionActionDetails">seekTime</dfn>
     <a>dictionary member</a> MUST be provided and is the time in seconds to
     move the playback time to.
   </li>
 
   <li>
-    The <dfn dict-member for="MediaSessionSeekToActionDetails">fastSeek</dfn>
+    The <dfn dict-member for="MediaSessionActionDetails">fastSeek</dfn>
     <a>dictionary member</a> MAY be provided and will be true if the
     <a lt="media session action">action</a> is being called multiple times
     as part of a sequence and this is not the last call in that sequence.
   </li>
 </ul>
-
-The <dfn dict-member for="MediaSessionPictureInPictureActionDetails">automatic</dfn>
-<a>dictionary member</a> MUST be provided when the <a>media session action</a>
-is <a enum-value for=MediaSessionAction>enterpictureinpicture</a>. This boolean
-distinguishes an explicit user action to enter picture-in-picture (e.g. a
-picture-in-picture button on the user agent) and an automatic picture-in-picture
-action from the user agent when the content is hidden.
 
 <h2 id="examples">Examples</h2>
 
@@ -1544,10 +1527,7 @@ action from the user agent when the content is hidden.
 <div class="example" id="example-enterpictureinpicture">
   Handling picture-in-picture:
   <pre class="lang-javascript">
-    navigator.mediaSession.setActionHandler("enterpictureinpicture", function(details) {
-      if (details.automatic && !mywebsite.userSettings.allowAutomaticPictureInPicture) {
-        return;
-      }
+    navigator.mediaSession.setActionHandler("enterpictureinpicture", function() {
       video.requestPictureInPicture();
     });
   </pre>

--- a/index.bs
+++ b/index.bs
@@ -458,6 +458,10 @@ conforming IDL fragments, as described in the Web IDL specification. [[!WEBIDL]]
           <dfn enum-value for=MediaSessionAction>nextslide</dfn>: the action's intent
           is to go to the next slide when presenting slides.
         </li>
+        <li>
+          <dfn enum-value for=MediaSessionAction>enterpictureinpicture</dfn>: the action's intent
+          is to open the playback in a picture-in-picture window.
+        </li>
       </ul>
     </p>
 
@@ -749,7 +753,8 @@ enum MediaSessionAction {
   "togglecamera",
   "hangup",
   "previousslide",
-  "nextslide"
+  "nextslide",
+  "enterpictureinpicture"
 };
 
 callback MediaSessionActionHandler = undefined(MediaSessionActionDetails details);
@@ -1227,9 +1232,19 @@ should always be positive.
 
 dictionary MediaSessionActionDetails {
   required MediaSessionAction action;
+};
+
+dictionary MediaSessionSeekActionDetails : MediaSessionActionDetails {
   double seekOffset;
+};
+
+dictionary MediaSessionSeekToActionDetails : MediaSessionActionDetails {
   double seekTime;
   boolean fastSeek;
+};
+
+dictionary MediaSessionPictureInPictureActionDetails : MediaSessionActionDetails {
+  boolean automatic;
 };
 </pre>
 
@@ -1242,7 +1257,7 @@ member</a>
 is used to specify the <a>media session action</a> that the
 {{MediaSessionActionHandler}} is associated with.
 
-The <dfn dict-member for="MediaSessionActionDetails">seekOffset</dfn>
+The <dfn dict-member for="MediaSessionSeekActionDetails">seekOffset</dfn>
 <a>dictionary member</a> MAY be provided when the <a>media session action</a>
 is <a enum-value for=MediaSessionAction>seekbackward</a> or
 <a enum-value for=MediaSessionAction>seekforward</a>. It is the time in seconds
@@ -1254,18 +1269,25 @@ When the <a>media session action</a> is
 
 <ul>
   <li>
-    The <dfn dict-member for="MediaSessionActionDetails">seekTime</dfn>
+    The <dfn dict-member for="MediaSessionSeekToActionDetails">seekTime</dfn>
     <a>dictionary member</a> MUST be provided and is the time in seconds to
     move the playback time to.
   </li>
 
   <li>
-    The <dfn dict-member for="MediaSessionActionDetails">fastSeek</dfn>
+    The <dfn dict-member for="MediaSessionSeekToActionDetails">fastSeek</dfn>
     <a>dictionary member</a> MAY be provided and will be true if the
     <a lt="media session action">action</a> is being called multiple times
     as part of a sequence and this is not the last call in that sequence.
   </li>
 </ul>
+
+The <dfn dict-member for="MediaSessionPictureInPictureActionDetails">automatic</dfn>
+<a>dictionary member</a> MUST be provided when the <a>media session action</a>
+is <a enum-value for=MediaSessionAction>enterpictureinpicture</a>. This boolean
+distinguishes an explicit user action to enter picture-in-picture (e.g. a
+picture-in-picture button on the user agent) and an automatic picture-in-picture
+action from the user agent when the content is hidden.
 
 <h2 id="examples">Examples</h2>
 
@@ -1515,6 +1537,18 @@ When the <a>media session action</a> is
     navigator.mediaSession.setActionHandler("nextslide", function() {
       currentSlideIndex++;
       // Set current slide. Implementation omitted.
+    });
+  </pre>
+</div>
+
+<div class="example" id="example-enterpictureinpicture">
+  Handling picture-in-picture:
+  <pre class="lang-javascript">
+    navigator.mediaSession.setActionHandler("enterpictureinpicture", function(details) {
+      if (details.automatic && !mywebsite.userSettings.allowAutomaticPictureInPicture) {
+        return;
+      }
+      video.requestPictureInPicture();
     });
   </pre>
 </div>

--- a/index.bs
+++ b/index.bs
@@ -24,7 +24,7 @@ Abstract: notification areas and on lock screens of mobile devices.
 Ignored Vars: context, media, session
 </pre>
 
-<style>
+<style> 
   /* https://github.com/tabatkins/bikeshed/issues/485 */
   .example .self-link { display: none; }
 </style>

--- a/index.bs
+++ b/index.bs
@@ -24,7 +24,7 @@ Abstract: notification areas and on lock screens of mobile devices.
 Ignored Vars: context, media, session
 </pre>
 
-<style> 
+<style>
   /* https://github.com/tabatkins/bikeshed/issues/485 */
   .example .self-link { display: none; }
 </style>

--- a/index.bs
+++ b/index.bs
@@ -1528,7 +1528,7 @@ When the <a>media session action</a> is
   Handling picture-in-picture:
   <pre class="lang-javascript">
     navigator.mediaSession.setActionHandler("enterpictureinpicture", function() {
-      video.requestPictureInPicture();
+      remoteVideo.requestPictureInPicture();
     });
   </pre>
 </div>

--- a/index.bs
+++ b/index.bs
@@ -460,7 +460,7 @@ conforming IDL fragments, as described in the Web IDL specification. [[!WEBIDL]]
         </li>
         <li>
           <dfn enum-value for=MediaSessionAction>enterpictureinpicture</dfn>: the action's intent
-          is to open the playback in a picture-in-picture window.
+          is to open the media session in a picture-in-picture window.
         </li>
       </ul>
     </p>


### PR DESCRIPTION
This PR adds a new 'enterpictureinpicture' MediaSessionAction as proposed in issue #294.

Notably, this has an 'automatic' boolean in the given MediaSessionActionDetails. This would allow websites to distinguish between 'enterpictureinpicture' actions coming from an explicit user action (e.g. clicking a picture-in-picture button in the user agent UI) vs the user agent automatically sending the action (e.g. because the website became hidden). This would not require a user agent to *ever* send such an action.

I'm interested in feedback on this approach, and here are two other approaches I considered for allowing a website to distinguish between the two:
1) Having two separate actions for each type ('enterpictureinpicture' and 'enterautopictureinpicture'/'autoenterpictureinpicture')
2) Adding some sort of 'source' enum that could potentially be useful for other MediaSessionActions and/or other sources of actions (I couldn't think of any other cases, but it's worth considering)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/pull/295.html" title="Last updated on Oct 11, 2023, 8:37 PM UTC (defc822)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/295/b2914fe...defc822.html" title="Last updated on Oct 11, 2023, 8:37 PM UTC (defc822)">Diff</a>