### PR TITLE
Change specification name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Media Session Standard
+# Media Session API
 
 https://w3c.github.io/mediasession/
 

--- a/index.bs
+++ b/index.bs
@@ -1,5 +1,5 @@
 <pre class="metadata">
-Title: Media Session Standard
+Title: Media Session
 Repository: w3c/mediasession
 Status: ED
 ED: https://w3c.github.io/mediasession/


### PR DESCRIPTION
This drops "Standard" from the spec name - @steimelchrome, @youennf are you OK with this change?

See https://github.com/w3c/mediasession/issues/248.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/pull/298.html" title="Last updated on Aug 10, 2023, 4:47 PM UTC (23e1539)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/298/b2914fe...23e1539.html" title="Last updated on Aug 10, 2023, 4:47 PM UTC (23e1539)">Diff</a>