### PR TITLE
Add permissions policy for mediasession

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -75,6 +75,13 @@ urlPrefix: https://fetch.spec.whatwg.org/; spec: FETCH
 urlPrefix: https://tc39.es/ecma262/#sec-object.; spec: WEBIDL;
     type: dfn
         text: freeze
+urlPrefix: https://www.w3.org/TR/permissions-policy-1/; spec: PermissionsPolicy
+    type: dfn;
+        text: policy-controlled feature; url:#policy-controlled-feature
+        text: default allowlist; url:#policy-controlled-feature-default-allowlist
+urlPrefix: https://html.spec.whatwg.org/multipage/dom.html; spec: dom
+    type: dfn
+        text: permissions policy; url:#concept-document-permissions-policy
 </pre>
 
 <h2 id="introduction">Introduction</h2>
@@ -1266,6 +1273,14 @@ When the <a>media session action</a> is
     as part of a sequence and this is not the last call in that sequence.
   </li>
 </ul>
+
+<h2 id="permissions-policy">Permissions Policy Integration</h2>
+
+This specification defines a <a>policy-controlled feature</a> identified by the
+string "mediasession". Its <a>default allowlist</a> is *.
+
+A document's <a>permissions policy</a> determines whether any content in that document is allowed to use the MediaSession API.
+If disabled in the document, the User Agent MUST NOT select the document's media session as the <a>active media session</a>.
 
 <h2 id="examples">Examples</h2>
 


### PR DESCRIPTION
Set default value to '*' for now until we get a better sense of whether 'self' could be used instead.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediasession/pull/299.html" title="Last updated on Sep 12, 2023, 9:04 AM UTC (75c372c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/299/79be7cb...youennf:75c372c.html" title="Last updated on Sep 12, 2023, 9:04 AM UTC (75c372c)">Diff</a>