### PR TITLE
Update MediaPositionState WebIDL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -887,7 +887,7 @@ interface MediaSession {
       present, throw a <a exception>TypeError</a>.
     </li>
     <li>
-      If <var>state</var>'s <a dict-member for="MediaPositionState">duration</a> is negative or
+      If <var>state</var>'s {{MediaPositionState/duration}} is negative or
       <code>NaN</code>, throw a <a exception>TypeError</a>.
     </li>
     <li>

--- a/index.bs
+++ b/index.bs
@@ -902,7 +902,7 @@ interface MediaSession {
       If <var>state</var>'s <a dict-member for="MediaPositionState">playbackRate</a> is not present, set it to 1.0.
     </li>
     <li>
-      If <var>state</var>'s <a dict-member for="MediaPositionState">playbackRate</a> is zero,
+      If <var>state</var>'s {{MediaPositionState/playbackRate}} is zero,
       throw a <a exception>TypeError</a>.
     </li>
     <li>

--- a/index.bs
+++ b/index.bs
@@ -891,7 +891,7 @@ interface MediaSession {
       <code>NaN</code>, throw a <a exception>TypeError</a>.
     </li>
     <li>
-      If <var>state</var>'s <a dict-member for="MediaPositionState">position</a> is not present, set it to zero.
+      If <var>state</var>'s {{MediaPositionState/position}} is not present, set it to zero.
     </li>
     <li>
       If <var>state</var>'s <a dict-member for="MediaPositionState">position</a> is negative or

--- a/index.bs
+++ b/index.bs
@@ -891,9 +891,15 @@ interface MediaSession {
       <code>NaN</code>, throw a <a exception>TypeError</a>.
     </li>
     <li>
+      If <var>state</var>'s <a dict-member for="MediaPositionState">position</a> is not present, set it to zero.
+    </li>
+    <li>
       If <var>state</var>'s <a dict-member for="MediaPositionState">position</a> is negative or
       greater than <a dict-member for="MediaPositionState">duration</a>, throw a
       <a exception>TypeError</a>.
+    </li>
+    <li>
+      If <var>state</var>'s <a dict-member for="MediaPositionState">playbackRate</a> is not present, set it to 1.0.
     </li>
     <li>
       If <var>state</var>'s <a dict-member for="MediaPositionState">playbackRate</a> is zero,
@@ -1197,8 +1203,8 @@ dictionary</h2>
 
 dictionary MediaPositionState {
   unrestricted double duration;
-  double playbackRate = 1.0;
-  double position = 0.0;
+  double playbackRate;
+  double position;
 };
 </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -879,32 +879,24 @@ interface MediaSession {
 
   <ul>
     <li>
-      If the <var>state</var> is an empty dictionary then clear the <a>position
-      state</a>.
+      If <var>state</var> is an empty dictionary, clear the <a>position state</a>
+      and abort these steps.
     </li>
     <li>
-      If the <a dict-member for="MediaPositionState">duration</a> is not present
-      or its value is null, throw a <a exception>TypeError</a>.
+      If <var>state</var>'s <a dict-member for="MediaPositionState">duration</a> is not
+      present, throw a <a exception>TypeError</a>.
     </li>
     <li>
-      If the <a dict-member for="MediaPositionState">duration</a> is negative,
-      throw a <a exception>TypeError</a>.
+      If <var>state</var>'s <a dict-member for="MediaPositionState">duration</a> is negative or
+      <code>NaN</code>, throw a <a exception>TypeError</a>.
     </li>
     <li>
-      If the <a dict-member for="MediaPositionState">position</a> is not present
-      or its value is null, set it to zero.
-    </li>
-    <li>
-      If the <a dict-member for="MediaPositionState">position</a> is negative or
+      If <var>state</var>'s <a dict-member for="MediaPositionState">position</a> is negative or
       greater than <a dict-member for="MediaPositionState">duration</a>, throw a
       <a exception>TypeError</a>.
     </li>
     <li>
-      If the <a dict-member for="MediaPositionState">playbackRate</a> is not
-      present or its value is null, set it to 1.0.
-    </li>
-    <li>
-      If the <a dict-member for="MediaPositionState">playbackRate</a> is zero
+      If <var>state</var>'s <a dict-member for="MediaPositionState">playbackRate</a> is zero,
       throw a <a exception>TypeError</a>.
     </li>
     <li>
@@ -1204,9 +1196,9 @@ dictionary</h2>
 <pre class="idl">
 
 dictionary MediaPositionState {
-  double duration;
-  double playbackRate;
-  double position;
+  unrestricted double duration;
+  double playbackRate = 1.0;
+  double position = 0.0;
 };
 </pre>
 


### PR DESCRIPTION
Fixes #303 
Fixes #252
 
We make duration a required member of MediaPositionState and add default values for position and playbackRate. duration is now unrestricted to allow Infinity, we add a special check for NaN.

We update MediaSession.setPositionState to accept null since MediaPositionState now has a required member.

This overtakes https://github.com/w3c/mediasession/issues/303 and should fix https://github.com/w3c/mediasession/issues/303 and https://github.com/w3c/mediasession/issues/252.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediasession/pull/304.html" title="Last updated on Jan 18, 2024, 9:22 AM UTC (5837bd7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/304/5d4054a...youennf:5837bd7.html" title="Last updated on Jan 18, 2024, 9:22 AM UTC (5837bd7)">Diff</a>