### PR TITLE
Update index.bs with ChapterInformation

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -107,8 +107,9 @@ interface MediaSession : EventTarget {
 ### The `MediaMetadata` interface
 
 A `MediaMetadata` object can contain media metadata like title, artist, album
-and album art. To set the metadata for a `MediaSession`, the page should create
-a `MediaMetadata` object and assign it to a `MediaSession` object:
+album art and video chapter information. To set the metadata for a `MediaSession`,
+the page should create a `MediaMetadata` object and assign it to a `MediaSession`
+object:
 
 ```javascript
 navigator.mediaSession.metadata = new MediaMetadata(/* MediaMetadata constructor */);
@@ -123,12 +124,19 @@ interface MediaMetadata {
     attribute DOMString artist;
     attribute DOMString album;
     attribute FrozenArray<MediaImage> artwork;
+    attribute FrozenArray<ChapterInformation> chapterInfo;
 };
 
 dictionary MediaImage {
   required USVString src;
   DOMString sizes = "";
   DOMString type = "";
+};
+
+dictionary ChapterInformation {
+  DOMString title = "";
+  double startTime = 0;
+  attribute FrozenArray<MediaImage> artwork;
 };
 ```
 

--- a/explainer.md
+++ b/explainer.md
@@ -136,7 +136,7 @@ dictionary MediaImage {
 interface ChapterInformation {
   attribute DOMString title;
   attribute double startTime;
-  readonly attribute FrozenArray<MediaImage> artwork;
+  [SameObject] readonly attribute FrozenArray<MediaImage> artwork;
 };
 ```
 

--- a/explainer.md
+++ b/explainer.md
@@ -133,9 +133,9 @@ dictionary MediaImage {
   DOMString type = "";
 };
 
-dictionary ChapterInformation {
-  DOMString title = "";
-  double startTime = 0;
+interface ChapterInformation {
+  DOMString title;
+  double startTime;
   attribute FrozenArray<MediaImage> artwork;
 };
 ```

--- a/explainer.md
+++ b/explainer.md
@@ -124,7 +124,7 @@ interface MediaMetadata {
     attribute DOMString artist;
     attribute DOMString album;
     attribute FrozenArray<MediaImage> artwork;
-[SameObject] readonly attribute FrozenArray<ChapterInformation> chapterInfo;
+    [SameObject] readonly attribute FrozenArray<ChapterInformation> chapterInfo;
 };
 
 dictionary MediaImage {

--- a/explainer.md
+++ b/explainer.md
@@ -124,7 +124,7 @@ interface MediaMetadata {
     attribute DOMString artist;
     attribute DOMString album;
     attribute FrozenArray<MediaImage> artwork;
-    readonly attribute FrozenArray<ChapterInformation> chapterInfo;
+[SameObject] readonly attribute FrozenArray<ChapterInformation> chapterInfo;
 };
 
 dictionary MediaImage {

--- a/explainer.md
+++ b/explainer.md
@@ -134,8 +134,8 @@ dictionary MediaImage {
 };
 
 interface ChapterInformation {
-  DOMString title;
-  double startTime;
+  attribute DOMString title;
+  attribute double startTime;
   attribute FrozenArray<MediaImage> artwork;
 };
 ```

--- a/explainer.md
+++ b/explainer.md
@@ -106,8 +106,8 @@ interface MediaSession : EventTarget {
 
 ### The `MediaMetadata` interface
 
-A `MediaMetadata` object can contain media metadata like title, artist, album
-album art and video chapter information. To set the metadata for a `MediaSession`,
+A `MediaMetadata` object can contain media metadata likelike title, artist, album,
+artwork, and video chapter information. To set the metadata for a `MediaSession`,
 the page should create a `MediaMetadata` object and assign it to a `MediaSession`
 object:
 

--- a/explainer.md
+++ b/explainer.md
@@ -124,7 +124,7 @@ interface MediaMetadata {
     attribute DOMString artist;
     attribute DOMString album;
     attribute FrozenArray<MediaImage> artwork;
-    attribute FrozenArray<ChapterInformation> chapterInfo;
+    readonly attribute FrozenArray<ChapterInformation> chapterInfo;
 };
 
 dictionary MediaImage {
@@ -136,7 +136,7 @@ dictionary MediaImage {
 interface ChapterInformation {
   attribute DOMString title;
   attribute double startTime;
-  attribute FrozenArray<MediaImage> artwork;
+  readonly attribute FrozenArray<MediaImage> artwork;
 };
 ```
 

--- a/explainer.md
+++ b/explainer.md
@@ -133,6 +133,7 @@ dictionary MediaImage {
   DOMString type = "";
 };
 
+[Exposed=Window]
 interface ChapterInformation {
   attribute DOMString title;
   attribute double startTime;

--- a/explainer.md
+++ b/explainer.md
@@ -135,8 +135,8 @@ dictionary MediaImage {
 
 [Exposed=Window]
 interface ChapterInformation {
-  attribute DOMString title;
-  attribute double startTime;
+  readonly attribute DOMString title;
+  readonly attribute double startTime;
   [SameObject] readonly attribute FrozenArray<MediaImage> artwork;
 };
 ```

--- a/explainer.md
+++ b/explainer.md
@@ -106,7 +106,7 @@ interface MediaSession : EventTarget {
 
 ### The `MediaMetadata` interface
 
-A `MediaMetadata` object can contain media metadata likelike title, artist, album,
+A `MediaMetadata` object can contain media metadata like title, artist, album,
 artwork, and video chapter information. To set the metadata for a `MediaSession`,
 the page should create a `MediaMetadata` object and assign it to a `MediaSession`
 object:

--- a/index.bs
+++ b/index.bs
@@ -1252,46 +1252,6 @@ artwork images</dfn>.
   </ol>
 </p>
 
-When the <a>convert artwork algorithm</a> with <var>input</var> parameter is
-invoked, the user agent MUST run the following steps:
-<ol>
-  <li>
-    Let <var>output</var> be an empty list of type {{MediaImage}}.
-  </li>
-  <li>
-    For each <var>entry</var> in <var>input</var>'s
-    {{ChapterInformationInit/artwork}}, perform the following steps:
-    <ol>
-      <li>
-        <!-- TODO: https://github.com/w3c/mediasession/issues/237 -->
-        Let <var>image</var> be a new {{MediaImage}}.
-      </li>
-      <li>Let <var>baseURL</var> be the API base URL specified by the <a>entry
-      settings object</a>. </li>
-      <li>
-        <a lt="url parser">Parse</a> <var>entry</var>'s {{MediaImage/src}} using
-        <var>baseURL</var>. If it does not return failure, set
-        <var>image</var>'s {{MediaImage/src}} to the return value. Otherwise,
-        throw a <a exception>TypeError</a> and abort these steps.
-      </li>
-      <li>
-        Set <var>image</var>'s {{MediaImage/sizes}} to <var>entry</var>'s
-        {{MediaImage/sizes}}.
-      </li>
-      <li>
-        Set <var>image</var>'s {{MediaImage/type}} to <var>entry</var>'s
-        {{MediaImage/type}}.
-      </li>
-      <li>
-        Append <var>image</var> to the <var>output</var>.
-      </li>
-    </ol>
-  </li>
-  <li>
-    Return <var>output</var> as result.
-  </li>
-</ol>
-
 <p>
   The <dfn attribute for="ChapterInformation">title</dfn> attribute
   reflects the {{ChapterInformation}}'s <a for=ChapterInformation>title</a>. On getting,

--- a/index.bs
+++ b/index.bs
@@ -940,7 +940,7 @@ interface MediaMetadata {
   attribute DOMString artist;
   attribute DOMString album;
   attribute FrozenArray&lt;MediaImage> artwork;
-  attribute sequence&lt;ChapterInformation> chapterInfo;
+  readonly attribute FrozenArray&lt;ChapterInformation> chapterInfo;
 };
 
 dictionary MediaMetadataInit {
@@ -1178,13 +1178,13 @@ interface ChapterInformation {
   constructor(optional ChapterInformationInit init = {});
   attribute DOMString title;
   attribute double startTime;
-  attribute FrozenArray&lt;MediaImage> artwork;
+  readonly attribute FrozenArray&lt;MediaImage> artwork;
 };
 
 dictionary ChapterInformationInit {
   DOMString title = "";
   double startTime = 0;
-  attribute FrozenArray&lt;MediaImage> artwork = [];
+  sequence&lt;MediaImage> artwork = [];
 };
 
 </pre>

--- a/index.bs
+++ b/index.bs
@@ -1046,8 +1046,8 @@ invoked, the user agent MUST run the following steps:
     Let <var>output</var> be an empty list of type {{MediaImage}}.
   </li>
   <li>
-    For each <var>entry</var> (which is a {{MediaImage}}) in <var>input</var> 
-(which is a {{MediaImage}} list), perform the following steps:
+    For each <var>entry</var> in <var>input</var> (which is a {{MediaImage}} list), 
+perform the following steps:
     <ol>
       <li>
         Let <var>image</var> be a new {{MediaImage}}.

--- a/index.bs
+++ b/index.bs
@@ -1301,7 +1301,7 @@ invoked, the user agent MUST run the following steps:
 
 <p>
   The <dfn attribute for="ChapterInformation">startTime</dfn> attribute
-  reflects the {{ChapterInformation}}'s <a for=ChapterInformation>startTime</a>. On getting,
+  reflects the {{ChapterInformation}}'s <a for=ChapterInformation>startTime</a> in seconds. On getting,
   it MUST return the {{ChapterInformation}}'s <a for=ChapterInformation>startTime</a>. On
   setting, it MUST set the {{ChapterInformation}}'s <a for=ChapterInformation>startTime</a>
   to the given value. If the <a for=ChapterInformation>startTime</a> is negative or greater than

--- a/index.bs
+++ b/index.bs
@@ -1046,8 +1046,8 @@ invoked, the user agent MUST run the following steps:
     Let <var>output</var> be an empty list of type {{MediaImage}}.
   </li>
   <li>
-    For each <var>entry</var> (which is an {{artwork}}) in <var>input</var> 
-(which is an {{artwork}} list), perform the following steps:
+    For each <var>entry</var> (which is a {{MediaImage}}) in <var>input</var> 
+(which is a {{MediaImage}} list), perform the following steps:
     <ol>
       <li>
         Let <var>image</var> be a new {{MediaImage}}.

--- a/index.bs
+++ b/index.bs
@@ -940,7 +940,7 @@ interface MediaMetadata {
   attribute DOMString artist;
   attribute DOMString album;
   attribute FrozenArray&lt;MediaImage> artwork;
-  readonly attribute FrozenArray&lt;ChapterInformation> chapterInfo;
+  attribute sequence&lt;ChapterInformation> chapterInfo;
 };
 
 dictionary MediaMetadataInit {
@@ -948,7 +948,7 @@ dictionary MediaMetadataInit {
   DOMString artist = "";
   DOMString album = "";
   sequence&lt;MediaImage> artwork = [];
-  sequence&lt;ChapterInformation> chapterInfo = [];
+  sequence&lt;ChapterInformationInit> chapterInfo = [];
 };
 </pre>
 
@@ -1170,15 +1170,23 @@ invoked, the user agent MUST run the following steps:
   </ol>
 </p>
 
-<h2 id="the-chapterinformation-dictionary">The {{ChapterInformation}} dictionary</h2>
+<h2 id="the-chapterinformation-interface">The {{ChapterInformation}} interface</h2>
 
 <pre class="idl">
 
-dictionary ChapterInformation {
-  DOMString title = "";
-  double startTime = 0;
+interface ChapterInformation {
+  constructor(optional ChapterInformationInit init = {});
+  DOMString title;
+  double startTime;
   attribute FrozenArray&lt;MediaImage> artwork;
 };
+
+interface ChapterInformationInit {
+  DOMString title = "";
+  double startTime = 0;
+  attribute FrozenArray&lt;MediaImage> artwork = [];
+};
+
 </pre>
 
 The <dfn dict-member for="ChapterInformation">title</dfn> <a>dictionary member</a> is

--- a/index.bs
+++ b/index.bs
@@ -1238,7 +1238,7 @@ artwork images</dfn>.
     <li>
       Set <var>chapterInfo</var>'s {{ChapterInformation/startTime}} to <var>init</var>'s
       {{ChapterInformationInit/startTime}}. If the <a for=ChapterInformation>startTime</a> is
-      negative or greater than [=duration=], throw
+      negative, greater than [=duration=], or <code>NaN</code>, throw
       a <a exception>TypeError</a>.
     </li>
     <li>

--- a/index.bs
+++ b/index.bs
@@ -1230,7 +1230,7 @@ artwork images</dfn>.
       Set <var>chapterInfo</var>'s {{ChapterInformation/startTime}} to <var>init</var>'s
       {{ChapterInformationInit/startTime}}. If the <a for=ChapterInformation>startTime</a> is
       negative or greater than <a dict-member for="MediaPositionState">duration</a>, throw
-      a <a exception>TypeError</a>
+      a <a exception>TypeError</a>.
     </li>
     <li>
       Run the <a>convert artwork algorithm</a> with <var>init</var>'s

--- a/index.bs
+++ b/index.bs
@@ -1173,7 +1173,6 @@ invoked, the user agent MUST run the following steps:
 <h2 id="the-chapterinformation-interface">The {{ChapterInformation}} interface</h2>
 
 <pre class="idl">
-A {{ChapterInformation}} object is a representation of metadata for an individual chapter, such as the title of the section, its timestamp, and screenshot image data of this section, that can be used by user agents to provide a customized user interface. 
 interface ChapterInformation {
   constructor(optional ChapterInformationInit init = {});
   readonly attribute DOMString title;
@@ -1189,16 +1188,132 @@ dictionary ChapterInformationInit {
 
 </pre>
 
-The <dfn dict-member for="ChapterInformation">title</dfn> <a>dictionary member</a> is
-used to specify the {{ChapterInformation}} object's {{MediaImage/title}}. 
+<p>
+  A {{ChapterInformation}} object is a representation of metadata for an individual
+  chapter, such as the title of the section, its timestamp, and screenshot image data
+  of this section, that can be used by user agents to provide a customized user interface. 
+</p>
 
-The <dfn dict-member for="ChapterInformation">startTime</dfn> <a>dictionary member</a>
-is used to specify the {{ChapterInformation}} object's {{MediaImage/startTime}} in
-seconds. It should not be negative.
+<p>
+  A {{ChapterInformation}} can have an associated <dfn for="ChapterInformation">
+  MediaMetadata</dfn>.
+</p>
 
-The <dfn dict-member for="ChapterInformation">artwork</dfn> <a>dictionary member</a>
-is used to specify the {{ChapterInformation}} object's {{MediaImage/artwork}}. On 
-getting, it MUST return the result of the following steps:
+<p>
+  A {{ChapterInformation}} has an associated <dfn for="ChapterInformation">title</dfn>
+  which is DOMString.
+</p>
+
+<p>
+  A {{ChapterInformation}} has an associated <dfn for="ChapterInformation">
+  startTime</dfn> which is double.
+</p>
+
+<p>
+  A {{ChapterInformation}} has an associated list of <dfn for="ChapterInformation">
+artwork images</dfn>.
+</p>
+
+<p>
+  A {{ChapterInformation}} is said to be an <dfn>empty metadata</dfn> if it is equal
+  to `null` or all the following conditions are true:
+  <ul>
+    <li>Its <a for=ChapterInformation>title</a> is the empty string.</li>
+    <li>Its <a for=ChapterInformation>startTime</a> is <code>0</code>.</li>
+    <li>Its <a for=ChapterInformation title='artwork image'>artwork images</a> length
+    is <code>0</code>.</li>
+  </ul>
+</p>
+
+<p>
+  The <dfn constructor
+  for="ChapterInformation">ChapterInformation(<var>init</var>)</dfn>
+  constructor, when invoked, MUST run the following steps:
+
+  <ol>
+    <li>
+      Let <var>chapterInfo</var> be a new {{ChapterInformation}} object.
+    </li>
+    <li>
+      Set <var>chapterInfo</var>'s {{ChapterInformation/title}} to <var>init</var>'s
+      {{ChapterInformationInit/title}}.
+    </li>
+    <li>
+      Set <var>chapterInfo</var>'s {{ChapterInformation/startTime}} to <var>init</var>'s
+      {{ChapterInformationInit/startTime}}.
+    </li>
+    <li>
+      Run the <a>convert artwork algorithm</a> with <var>init</var>'s
+      {{ChapterInformationInit/artwork}} as <var>input</var> and set
+      <var>chapterInfo</var>'s <a for="ChapterInformation">artwork images</a> as the
+      result if it succeeded.
+    </li>
+    <li>
+      Return <var>chapterInfo</var>.
+    </li>
+  </ol>
+</p>
+
+When the <dfn>convert artwork algorithm</dfn> with <var>input</var> parameter is
+invoked, the user agent MUST run the following steps:
+<ol>
+  <li>
+    Let <var>output</var> be an empty list of type {{MediaImage}}.
+  </li>
+  <li>
+    For each <var>entry</var> in <var>input</var>'s
+    {{ChapterInformationInit/artwork}}, perform the following steps:
+    <ol>
+      <li>
+        Let <var>image</var> be a new {{MediaImage}}.
+      </li>
+      <li>Let <var>baseURL</var> be the API base URL specified by the <a>entry
+      settings object</a>. </li>
+      <li>
+        <a lt="url parser">Parse</a> <var>entry</var>'s {{MediaImage/src}} using
+        <var>baseURL</var>. If it does not return failure, set
+        <var>image</var>'s {{MediaImage/src}} to the return value. Otherwise,
+        throw a <a exception>TypeError</a> and abort these steps.
+      </li>
+      <li>
+        Set <var>image</var>'s {{MediaImage/sizes}} to <var>entry</var>'s
+        {{MediaImage/sizes}}.
+      </li>
+      <li>
+        Set <var>image</var>'s {{MediaImage/type}} to <var>entry</var>'s
+        {{MediaImage/type}}.
+      </li>
+      <li>
+        Append <var>image</var> to the <var>output</var>.
+      </li>
+    </ol>
+  </li>
+  <li>
+    Return <var>output</var> as result.
+  </li>
+</ol>
+
+<p>
+  The <dfn attribute for="ChapterInformation">title</dfn> attribute
+  reflects the {{ChapterInformation}}'s <a for=ChapterInformation>title</a>. On getting,
+  it MUST return the {{ChapterInformation}}'s <a for=ChapterInformation>title</a>. On
+  setting, it MUST set the {{ChapterInformation}}'s <a for=ChapterInformation>title</a> to
+  the given value.
+</p>
+
+<p>
+  The <dfn attribute for="ChapterInformation">startTime</dfn> attribute
+  reflects the {{ChapterInformation}}'s <a for=ChapterInformation>startTime</a>. On getting,
+  it MUST return the {{ChapterInformation}}'s <a for=ChapterInformation>startTime</a>. On
+  setting, it MUST set the {{ChapterInformation}}'s <a for=ChapterInformation>startTime</a>
+  to the given value. If the <a for=ChapterInformation>startTime</a> is negative or greater than
+  <a dict-member for="MediaPositionState">duration</a>, throw a <a exception>TypeError</a>
+</p>
+
+<p>
+  The <dfn attribute for="ChapterInformation">artwork</dfn>
+  attribute reflects the {{ChapterInformation}}'s <a for="ChapterInformation">artwork
+  images</a>. On getting, it MUST return the result of the following steps:
   <ol>
     <li>
       Let <var>frozenArtwork</var> be an empty list of type {{MediaImage}}.
@@ -1240,11 +1355,36 @@ getting, it MUST return the result of the following steps:
       <a>Create a frozen array</a> from <var>frozenArtwork</var>.
     </li>
   </ol>
+  On setting, it MUST run the
+  <a>convert artwork algorithm</a> with the new value as <var>input</var>, and
+  set the {{ChapterInformation}}'s <a for="ChapterInformation">artwork images</a> as the
+  result if it succeeded.
+</p>
 
-On setting, it MUST run the <a>convert artwork algorithm</a> with the new value as
-<var>input</var>, and set the {{ChapterInformation}}'s <a for="ChapterInformation">artwork 
-images</a> as the result if it succeeded.
-
+<p>
+  When {{ChapterInformation}}'s <a for=ChapterInformation>title</a>, <a
+  for=ChapterInformation>startTime</a> or <a for=ChapterInformation>artwork images</a>
+  are modified, the user agent MUST run the following steps:
+  <ol>
+    <li>
+      If the instance has no associated [=ChapterInformation/media metadata=],
+      abort these steps.
+    </li>
+    <li>
+      Otherwise, <a>queue a task</a> to run the following substeps:
+      <ol>
+        <li>
+          If the instance no longer has an associated <a for=ChapterInformation>media
+          metadata</a>, abort these steps.
+        </li>
+        <li>
+          Otherwise, <a>in parallel</a>, run the <a>update metadata
+          algorithm</a>.
+        </li>
+      </ol>
+    </li>
+  </ol>
+</p>
 
 <h2 id="the-mediaimage-dictionary">The {{MediaImage}} dictionary</h2>
 

--- a/index.bs
+++ b/index.bs
@@ -1242,10 +1242,11 @@ artwork images</dfn>.
       a <a exception>TypeError</a>.
     </li>
     <li>
-      Run the <a>convert artwork algorithm</a> with <var>init</var>'s
-      {{ChapterInformationInit/artwork}} as <var>input</var> and set
-      <var>chapterInfo</var>'s <a for="ChapterInformation">artwork images</a> to the
-      result of [=Create a frozen array|creating a frozen array=] from the result.
+      Let {{ChapterInformationInit/artwork}} be the result of running the <a>convert artwork algorithm</a>.
+    </li>
+    <li>
+      Set <var>chapterInfo</var>'s <a for="ChapterInformation">artwork images</a> to the
+      result of [=Create a frozen array|creating a frozen array=] from {{ChapterInformationInit/artwork}}.
     </li>
     <li>
       Return <var>chapterInfo</var>.

--- a/index.bs
+++ b/index.bs
@@ -1021,7 +1021,8 @@ dictionary MediaMetadataInit {
       result if it succeeded.
     </li>
     <li>
-      Set <var>metadata</var>'s {{MediaMetadata/chapterInfo}} to
+      Create a list of {{ChapterInformation}} from the sequence of chapters. Then
+      freeze this list and set it to <var>metadata</var>'s {{MediaMetadata/chapterInfo}} to
       <var>init</var>'s {{MediaMetadataInit/chapterInfo}}.
     </li>
     <li>
@@ -1195,7 +1196,7 @@ dictionary ChapterInformationInit {
 
 <p>
   A {{ChapterInformation}} can have an associated <dfn for="ChapterInformation">
-  MediaMetadata</dfn>.
+  media metadata</dfn>.
 </p>
 
 <p>
@@ -1214,17 +1215,6 @@ artwork images</dfn>.
 </p>
 
 <p>
-  A {{ChapterInformation}} is said to be an <dfn>empty chapterInfo</dfn> if it is equal
-  to `null` or all the following conditions are true:
-  <ul>
-    <li>Its <a for=ChapterInformation>title</a> is the empty string.</li>
-    <li>Its <a for=ChapterInformation>startTime</a> is <code>0</code>.</li>
-    <li>Its <a for=ChapterInformation title='artwork image'>artwork images</a> length
-    is <code>0</code>.</li>
-  </ul>
-</p>
-
-<p>
   To <dfn>create a {{ChapterInformation}}</dfn> with <var>init</var>,
   run the following steps:
 
@@ -1238,13 +1228,16 @@ artwork images</dfn>.
     </li>
     <li>
       Set <var>chapterInfo</var>'s {{ChapterInformation/startTime}} to <var>init</var>'s
-      {{ChapterInformationInit/startTime}}.
+      {{ChapterInformationInit/startTime}}. If the <a for=ChapterInformation>startTime</a> is
+      negative or greater than <a dict-member for="MediaPositionState">duration</a>, throw
+      a <a exception>TypeError</a>
     </li>
     <li>
       Run the <a>convert artwork algorithm</a> with <var>init</var>'s
       {{ChapterInformationInit/artwork}} as <var>input</var> and set
-      <var>chapterInfo</var>'s <a for="ChapterInformation">artwork images</a> as the
-      result if it succeeded.
+      <var>chapterInfo</var>'s <a for="ChapterInformation">artwork images</a> to the
+      result of <a for="create a frozen array">creating a frozen array</a> from the result
+      of the <a>convert artwork algorithm</a>.
     </li>
     <li>
       Return <var>chapterInfo</var>.
@@ -1263,6 +1256,7 @@ invoked, the user agent MUST run the following steps:
     {{ChapterInformationInit/artwork}}, perform the following steps:
     <ol>
       <li>
+        <!-- TODO: https://github.com/w3c/mediasession/issues/237 -->
         Let <var>image</var> be a new {{MediaImage}}.
       </li>
       <li>Let <var>baseURL</var> be the API base URL specified by the <a>entry
@@ -1294,18 +1288,13 @@ invoked, the user agent MUST run the following steps:
 <p>
   The <dfn attribute for="ChapterInformation">title</dfn> attribute
   reflects the {{ChapterInformation}}'s <a for=ChapterInformation>title</a>. On getting,
-  it MUST return the {{ChapterInformation}}'s <a for=ChapterInformation>title</a>. On
-  setting, it MUST set the {{ChapterInformation}}'s <a for=ChapterInformation>title</a> to
-  the given value.
+  it MUST return the {{ChapterInformation}}'s <a for=ChapterInformation>title</a>.
 </p>
 
 <p>
   The <dfn attribute for="ChapterInformation">startTime</dfn> attribute
   reflects the {{ChapterInformation}}'s <a for=ChapterInformation>startTime</a> in seconds. On getting,
-  it MUST return the {{ChapterInformation}}'s <a for=ChapterInformation>startTime</a>. On
-  setting, it MUST set the {{ChapterInformation}}'s <a for=ChapterInformation>startTime</a>
-  to the given value. If the <a for=ChapterInformation>startTime</a> is negative or greater than
-  <a dict-member for="MediaPositionState">duration</a>, throw a <a exception>TypeError</a>
+  it MUST return the {{ChapterInformation}}'s <a for=ChapterInformation>startTime</a>.
 </p>
 
 <p>
@@ -1313,31 +1302,6 @@ invoked, the user agent MUST run the following steps:
   attribute reflects the {{ChapterInformation}}'s <a for="ChapterInformation">artwork
   images</a>. On getting, it MUST return the {{ChapterInformation}}'s <a for=ChapterInformation>
   artwork images</a>.
-</p>
-
-<p>
-  When {{ChapterInformation}}'s <a for=ChapterInformation>title</a>, <a
-  for=ChapterInformation>startTime</a> or <a for=ChapterInformation>artwork images</a>
-  are modified, the user agent MUST run the following steps:
-  <ol>
-    <li>
-      If the instance has no associated [=ChapterInformation/media metadata=],
-      abort these steps.
-    </li>
-    <li>
-      Otherwise, <a>queue a task</a> to run the following substeps:
-      <ol>
-        <li>
-          If the instance no longer has an associated <a for=ChapterInformation>media
-          metadata</a>, abort these steps.
-        </li>
-        <li>
-          Otherwise, <a>in parallel</a>, run the <a>update metadata
-          algorithm</a>.
-        </li>
-      </ol>
-    </li>
-  </ol>
 </p>
 
 <h2 id="the-mediaimage-dictionary">The {{MediaImage}} dictionary</h2>

--- a/index.bs
+++ b/index.bs
@@ -940,7 +940,7 @@ interface MediaMetadata {
   attribute DOMString artist;
   attribute DOMString album;
   attribute FrozenArray&lt;MediaImage> artwork;
-  readonly attribute FrozenArray&lt;ChapterInformation> chapterInfo;
+  [SameObject] readonly attribute FrozenArray&lt;ChapterInformation> chapterInfo;
 };
 
 dictionary MediaMetadataInit {

--- a/index.bs
+++ b/index.bs
@@ -940,7 +940,7 @@ interface MediaMetadata {
   attribute DOMString artist;
   attribute DOMString album;
   attribute FrozenArray&lt;MediaImage> artwork;
-  attribute FrozenArray<ChapterInformation> chapterInfo;
+  attribute FrozenArray&lt;ChapterInformation> chapterInfo;
 };
 
 dictionary MediaMetadataInit {
@@ -948,7 +948,7 @@ dictionary MediaMetadataInit {
   DOMString artist = "";
   DOMString album = "";
   sequence&lt;MediaImage> artwork = [];
-  sequence<ChapterInformation> chapterInfo = [];
+  sequence&lt;ChapterInformation> chapterInfo = [];
 };
 </pre>
 
@@ -1177,7 +1177,7 @@ invoked, the user agent MUST run the following steps:
 dictionary ChapterInformation {
   DOMString title = "";
   double startTime = "";
-  attribute FrozenArray<MediaImage> artwork;
+  attribute FrozenArray&lt;MediaImage> artwork;
 };
 </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -1046,8 +1046,8 @@ invoked, the user agent MUST run the following steps:
     Let <var>output</var> be an empty list of type {{MediaImage}}.
   </li>
   <li>
-    For each <var>entry</var> in <var>input</var>'s
-    {{MediaMetadataInit/artwork}}, perform the following steps:
+    For each <var>entry</var> (which is an {{artwork}}) in <var>input</var> 
+(which is an {{artwork}} list), perform the following steps:
     <ol>
       <li>
         Let <var>image</var> be a new {{MediaImage}}.

--- a/index.bs
+++ b/index.bs
@@ -940,6 +940,7 @@ interface MediaMetadata {
   attribute DOMString artist;
   attribute DOMString album;
   attribute FrozenArray&lt;MediaImage> artwork;
+  attribute FrozenArray<ChapterInformation> chapterInfo;
 };
 
 dictionary MediaMetadataInit {
@@ -947,6 +948,13 @@ dictionary MediaMetadataInit {
   DOMString artist = "";
   DOMString album = "";
   sequence&lt;MediaImage> artwork = [];
+  sequence<ChapterInformation> chapterInfo = [];
+};
+
+dictionary ChapterInformation {
+  DOMString title = "";
+  double startTime = "";
+  attribute FrozenArray<MediaImage> artwork;
 };
 </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -1176,7 +1176,7 @@ invoked, the user agent MUST run the following steps:
 
 dictionary ChapterInformation {
   DOMString title = "";
-  double startTime = "";
+  double startTime = 0;
   attribute FrozenArray&lt;MediaImage> artwork;
 };
 </pre>
@@ -1186,10 +1186,56 @@ used to specify the {{ChapterInformation}} object's {{MediaImage/title}}.
 
 The <dfn dict-member for="ChapterInformation">startTime</dfn> <a>dictionary member</a>
 is used to specify the {{ChapterInformation}} object's {{MediaImage/startTime}} in
-seconds. It should always be positive.
+seconds. It should not be negative.
 
 The <dfn dict-member for="ChapterInformation">artwork</dfn> <a>dictionary member</a>
-is used to specify the {{ChapterInformation}} object's {{MediaImage/artwork}}.
+is used to specify the {{ChapterInformation}} object's {{MediaImage/artwork}}. On 
+getting, it MUST return the result of the following steps:
+  <ol>
+    <li>
+      Let <var>frozenArtwork</var> be an empty list of type {{MediaImage}}.
+    </li>
+    <li>
+      For each <var>entry</var> in the {{ChapterInformation}}'s <a
+      for="MediaMetadata">artwork images</a>, perform the following steps:
+      <ol>
+        <li>
+          Let <var>image</var> be a new {{MediaImage}}.
+        </li>
+        <li>
+          Set <var>image</var>'s {{MediaImage/src}} to <var>entry</var>'s
+          {{MediaImage/src}}.
+        </li>
+        <li>
+          Set <var>image</var>'s {{MediaImage/sizes}} to <var>entry</var>'s
+          {{MediaImage/sizes}}.
+        </li>
+        <li>
+          Set <var>image</var>'s {{MediaImage/type}} to <var>entry</var>'s
+          {{MediaImage/type}}.
+        </li>
+        <!-- XXX IDL dictionaries are usually returned by value, so don't need
+        to be immutable. But FrozenArray reifies the dictionaries to mutable JS
+        objects accessed by reference, so we explicitly freeze them. It would be
+        better to do this with IDL primitives instead of JS - see
+        https://www.w3.org/Bugs/Public/show_bug.cgi?id=29004 -->
+        <li>
+          Call <a lt="freeze">Object.freeze</a> on <var>image</var>, to prevent
+          accidental mutation by scripts.
+        </li>
+        <li>
+          Append <var>image</var> to <var>frozenArtwork</var>.
+        </li>
+      </ol>
+    </li>
+    <li>
+      <a>Create a frozen array</a> from <var>frozenArtwork</var>.
+    </li>
+  </ol>
+
+On setting, it MUST run the <a>convert artwork algorithm</a> with the new value as
+<var>input</var>, and set the {{MediaMetadata}}'s <a for="ChapterInformation">artwork 
+images</a> as the result if it succeeded.
 
 
 <h2 id="the-mediaimage-dictionary">The {{MediaImage}} dictionary</h2>

--- a/index.bs
+++ b/index.bs
@@ -1182,6 +1182,7 @@ invoked, the user agent MUST run the following steps:
 <h2 id="the-chapterinformation-interface">The {{ChapterInformation}} interface</h2>
 
 <pre class="idl">
+[Exposed=Window]
 interface ChapterInformation {
   readonly attribute DOMString title;
   readonly attribute double startTime;

--- a/index.bs
+++ b/index.bs
@@ -1406,7 +1406,7 @@ If disabled in the document, the User Agent MUST NOT select the document's media
         {src: "podcast.png", sizes: "128x128", type: "image/png"},
         {src: "podcast_hd.png", sizes: "256x256", type: "image/png"},
         {src: "podcast.ico", sizes: "128x128 256x256", type: "image/x-icon"}
-      ]
+      ],
       chapterInfo: [
         {title: "Chapter 1", startTime: 0, artwork: [
            {src: "chapter1_a.jpg", sizes: "128x128", type: "image/jpeg"},

--- a/index.bs
+++ b/index.bs
@@ -950,12 +950,6 @@ dictionary MediaMetadataInit {
   sequence&lt;MediaImage> artwork = [];
   sequence<ChapterInformation> chapterInfo = [];
 };
-
-dictionary ChapterInformation {
-  DOMString title = "";
-  double startTime = "";
-  attribute FrozenArray<MediaImage> artwork;
-};
 </pre>
 
 <p>
@@ -981,6 +975,11 @@ dictionary ChapterInformation {
 </p>
 
 <p>
+  A {{MediaMetadata}} has an associated list of <dfn for="MediaMetadata">
+  chapter information</dfn>.
+</p>
+
+<p>
   A {{MediaMetadata}} is said to be an <dfn>empty metadata</dfn> if it is equal
   to <code>null</code> or all the following conditions are true:
   <ul>
@@ -988,6 +987,8 @@ dictionary ChapterInformation {
     <li>Its <a for=MediaMetadata>artist</a> is the empty string.</li>
     <li>Its <a for=MediaMetadata>album</a> is the empty string.</li>
     <li>Its <a for=MediaMetadata title='artwork image'>artwork images</a> length
+    is <code>0</code>.</li>
+    <li>Its <a for=MediaMetadata>chapter information</a> length
     is <code>0</code>.</li>
   </ul>
 </p>
@@ -1018,6 +1019,10 @@ dictionary ChapterInformation {
       {{MediaMetadataInit/artwork}} as <var>input</var> and set
       <var>metadata</var>'s <a for="MediaMetadata">artwork images</a> as the
       result if it succeeded.
+    </li>
+    <li>
+      Set <var>metadata</var>'s {{MediaMetadata/chapterInfo}} to
+      <var>init</var>'s {{MediaMetadataInit/chapterInfo}}.
     </li>
     <li>
       Return <var>metadata</var>.
@@ -1164,6 +1169,28 @@ invoked, the user agent MUST run the following steps:
     </li>
   </ol>
 </p>
+
+<h2 id="the-chapterinformation-dictionary">The {{ChapterInformation}} dictionary</h2>
+
+<pre class="idl">
+
+dictionary ChapterInformation {
+  DOMString title = "";
+  double startTime = "";
+  attribute FrozenArray<MediaImage> artwork;
+};
+</pre>
+
+The <dfn dict-member for="ChapterInformation">title</dfn> <a>dictionary member</a> is
+used to specify the {{ChapterInformation}} object's {{MediaImage/title}}. 
+
+The <dfn dict-member for="ChapterInformation">startTime</dfn> <a>dictionary member</a>
+is used to specify the {{ChapterInformation}} object's {{MediaImage/startTime}} in
+seconds. It should always be positive.
+
+The <dfn dict-member for="ChapterInformation">artwork</dfn> <a>dictionary member</a>
+is used to specify the {{ChapterInformation}} object's {{MediaImage/artwork}}.
+
 
 <h2 id="the-mediaimage-dictionary">The {{MediaImage}} dictionary</h2>
 

--- a/index.bs
+++ b/index.bs
@@ -1025,7 +1025,7 @@ dictionary MediaMetadataInit {
     </li>
     <li>
       For each <var>entry</var> in <var>init</var>'s {{MediaMetadataInit/chapterInfo}},
-      [=create a {{ChapterInformation}}=] from <var>entry</var> and append it to
+      [=create a ChapterInformation=] from <var>entry</var> and append it to
       <var>chapters</var>.
     </li>
     <li>

--- a/index.bs
+++ b/index.bs
@@ -1174,7 +1174,6 @@ invoked, the user agent MUST run the following steps:
 
 <pre class="idl">
 interface ChapterInformation {
-  constructor(optional ChapterInformationInit init = {});
   readonly attribute DOMString title;
   readonly attribute double startTime;
   [SameObject] readonly attribute FrozenArray&lt;MediaImage> artwork;

--- a/index.bs
+++ b/index.bs
@@ -1021,9 +1021,17 @@ dictionary MediaMetadataInit {
       result if it succeeded.
     </li>
     <li>
-      Create a list of {{ChapterInformation}} from the sequence of chapters. Then
-      freeze this list and set it to <var>metadata</var>'s {{MediaMetadata/chapterInfo}} to
-      <var>init</var>'s {{MediaMetadataInit/chapterInfo}}.
+      Let <var>chapters</var> be an empty list of type {{ChapterInformation}}.
+    </li>
+    <li>
+      For each <var>entry</var> in <var>init</var>'s {{MediaMetadataInit/chapterInfo}},
+      [=create a {{ChapterInformation}}=] from <var>entry</var> and append it to
+      <var>chapters</var>.
+    </li>
+    <li>
+      Set <var>metadata</var>'s <a for="MediaMetadata">chapter information</a> to the
+      result of [=Create a frozen array|creating a frozen array=] from
+      <var>chapters</var>.
     </li>
     <li>
       Return <var>metadata</var>.

--- a/index.bs
+++ b/index.bs
@@ -1176,8 +1176,8 @@ invoked, the user agent MUST run the following steps:
 
 interface ChapterInformation {
   constructor(optional ChapterInformationInit init = {});
-  attribute DOMString title;
-  attribute double startTime;
+  readonly attribute DOMString title;
+  readonly attribute double startTime;
   readonly attribute FrozenArray&lt;MediaImage> artwork;
 };
 

--- a/index.bs
+++ b/index.bs
@@ -1225,9 +1225,8 @@ artwork images</dfn>.
 </p>
 
 <p>
-  The <dfn constructor
-  for="ChapterInformation">ChapterInformation(<var>init</var>)</dfn>
-  constructor, when invoked, MUST run the following steps:
+  To <dfn>create a {{ChapterInformation}}</dfn> with <var>init</var>,
+  run the following steps:
 
   <ol>
     <li>

--- a/index.bs
+++ b/index.bs
@@ -1229,7 +1229,7 @@ artwork images</dfn>.
     <li>
       Set <var>chapterInfo</var>'s {{ChapterInformation/startTime}} to <var>init</var>'s
       {{ChapterInformationInit/startTime}}. If the <a for=ChapterInformation>startTime</a> is
-      negative or greater than <a dict-member for="MediaPositionState">duration</a>, throw
+      negative or greater than [=duration=], throw
       a <a exception>TypeError</a>.
     </li>
     <li>

--- a/index.bs
+++ b/index.bs
@@ -1215,7 +1215,7 @@ artwork images</dfn>.
 </p>
 
 <p>
-  A {{ChapterInformation}} is said to be an <dfn>empty metadata</dfn> if it is equal
+  A {{ChapterInformation}} is said to be an <dfn>empty chapterInfo</dfn> if it is equal
   to `null` or all the following conditions are true:
   <ul>
     <li>Its <a for=ChapterInformation>title</a> is the empty string.</li>

--- a/index.bs
+++ b/index.bs
@@ -1313,52 +1313,10 @@ invoked, the user agent MUST run the following steps:
 <p>
   The <dfn attribute for="ChapterInformation">artwork</dfn>
   attribute reflects the {{ChapterInformation}}'s <a for="ChapterInformation">artwork
-  images</a>. On getting, it MUST return the result of the following steps:
-  <ol>
-    <li>
-      Let <var>frozenArtwork</var> be an empty list of type {{MediaImage}}.
-    </li>
-    <li>
-      For each <var>entry</var> in the {{ChapterInformation}}'s <a
-      for="ChapterInformation">artwork images</a>, perform the following steps:
-      <ol>
-        <li>
-          Let <var>image</var> be a new {{MediaImage}}.
-        </li>
-        <li>
-          Set <var>image</var>'s {{MediaImage/src}} to <var>entry</var>'s
-          {{MediaImage/src}}.
-        </li>
-        <li>
-          Set <var>image</var>'s {{MediaImage/sizes}} to <var>entry</var>'s
-          {{MediaImage/sizes}}.
-        </li>
-        <li>
-          Set <var>image</var>'s {{MediaImage/type}} to <var>entry</var>'s
-          {{MediaImage/type}}.
-        </li>
-        <!-- XXX IDL dictionaries are usually returned by value, so don't need
-        to be immutable. But FrozenArray reifies the dictionaries to mutable JS
-        objects accessed by reference, so we explicitly freeze them. It would be
-        better to do this with IDL primitives instead of JS - see
-        https://www.w3.org/Bugs/Public/show_bug.cgi?id=29004 -->
-        <li>
-          Call <a lt="freeze">Object.freeze</a> on <var>image</var>, to prevent
-          accidental mutation by scripts.
-        </li>
-        <li>
-          Append <var>image</var> to <var>frozenArtwork</var>.
-        </li>
-      </ol>
-    </li>
-    <li>
-      <a>Create a frozen array</a> from <var>frozenArtwork</var>.
-    </li>
-  </ol>
-  On setting, it MUST run the
-  <a>convert artwork algorithm</a> with the new value as <var>input</var>, and
-  set the {{ChapterInformation}}'s <a for="ChapterInformation">artwork images</a> as the
-  result if it succeeded.
+  images</a>. On getting, it MUST return the {{ChapterInformation}}'s <a for=ChapterInformation>
+  artwork</a>. On setting, it MUST run the <a>convert artwork algorithm</a> with the new value as
+  <var>input</var>, and set the {{ChapterInformation}}'s <a for="ChapterInformation">artwork
+  images</a> as the result if it succeeded.
 </p>
 
 <p>

--- a/index.bs
+++ b/index.bs
@@ -1176,12 +1176,12 @@ invoked, the user agent MUST run the following steps:
 
 interface ChapterInformation {
   constructor(optional ChapterInformationInit init = {});
-  DOMString title;
-  double startTime;
+  attribute DOMString title;
+  attribute double startTime;
   attribute FrozenArray&lt;MediaImage> artwork;
 };
 
-interface ChapterInformationInit {
+dictionary ChapterInformationInit {
   DOMString title = "";
   double startTime = 0;
   attribute FrozenArray&lt;MediaImage> artwork = [];

--- a/index.bs
+++ b/index.bs
@@ -1173,7 +1173,7 @@ invoked, the user agent MUST run the following steps:
 <h2 id="the-chapterinformation-interface">The {{ChapterInformation}} interface</h2>
 
 <pre class="idl">
-
+A {{ChapterInformation}} object is a representation of metadata for an individual chapter, such as the title of the section, its timestamp, and screenshot image data of this section, that can be used by user agents to provide a customized user interface. 
 interface ChapterInformation {
   constructor(optional ChapterInformationInit init = {});
   readonly attribute DOMString title;

--- a/index.bs
+++ b/index.bs
@@ -1312,9 +1312,7 @@ invoked, the user agent MUST run the following steps:
   The <dfn attribute for="ChapterInformation">artwork</dfn>
   attribute reflects the {{ChapterInformation}}'s <a for="ChapterInformation">artwork
   images</a>. On getting, it MUST return the {{ChapterInformation}}'s <a for=ChapterInformation>
-  artwork</a>. On setting, it MUST run the <a>convert artwork algorithm</a> with the new value as
-  <var>input</var>, and set the {{ChapterInformation}}'s <a for="ChapterInformation">artwork
-  images</a> as the result if it succeeded.
+  artwork images</a>.
 </p>
 
 <p>

--- a/index.bs
+++ b/index.bs
@@ -1197,7 +1197,7 @@ getting, it MUST return the result of the following steps:
     </li>
     <li>
       For each <var>entry</var> in the {{ChapterInformation}}'s <a
-      for="MediaMetadata">artwork images</a>, perform the following steps:
+      for="ChapterInformation">artwork images</a>, perform the following steps:
       <ol>
         <li>
           Let <var>image</var> be a new {{MediaImage}}.
@@ -1234,7 +1234,7 @@ getting, it MUST return the result of the following steps:
   </ol>
 
 On setting, it MUST run the <a>convert artwork algorithm</a> with the new value as
-<var>input</var>, and set the {{MediaMetadata}}'s <a for="ChapterInformation">artwork 
+<var>input</var>, and set the {{ChapterInformation}}'s <a for="ChapterInformation">artwork 
 images</a> as the result if it succeeded.
 
 

--- a/index.bs
+++ b/index.bs
@@ -1178,7 +1178,7 @@ interface ChapterInformation {
   constructor(optional ChapterInformationInit init = {});
   readonly attribute DOMString title;
   readonly attribute double startTime;
-  readonly attribute FrozenArray&lt;MediaImage> artwork;
+  [SameObject] readonly attribute FrozenArray&lt;MediaImage> artwork;
 };
 
 dictionary ChapterInformationInit {

--- a/index.bs
+++ b/index.bs
@@ -1238,7 +1238,7 @@ artwork images</dfn>.
     <li>
       Set <var>chapterInfo</var>'s {{ChapterInformation/startTime}} to <var>init</var>'s
       {{ChapterInformationInit/startTime}}. If the <a for=ChapterInformation>startTime</a> is
-      negative, greater than [=duration=], or <code>NaN</code>, throw
+      negative or greater than [=duration=], throw
       a <a exception>TypeError</a>.
     </li>
     <li>

--- a/index.bs
+++ b/index.bs
@@ -940,7 +940,7 @@ interface MediaMetadata {
   attribute DOMString artist;
   attribute DOMString album;
   attribute FrozenArray&lt;MediaImage> artwork;
-  attribute FrozenArray&lt;ChapterInformation> chapterInfo;
+  readonly attribute FrozenArray&lt;ChapterInformation> chapterInfo;
 };
 
 dictionary MediaMetadataInit {

--- a/index.bs
+++ b/index.bs
@@ -1252,7 +1252,7 @@ artwork images</dfn>.
   </ol>
 </p>
 
-When the <dfn>convert artwork algorithm</dfn> with <var>input</var> parameter is
+When the <a>convert artwork algorithm</a> with <var>input</var> parameter is
 invoked, the user agent MUST run the following steps:
 <ol>
   <li>

--- a/index.bs
+++ b/index.bs
@@ -1236,8 +1236,7 @@ artwork images</dfn>.
       Run the <a>convert artwork algorithm</a> with <var>init</var>'s
       {{ChapterInformationInit/artwork}} as <var>input</var> and set
       <var>chapterInfo</var>'s <a for="ChapterInformation">artwork images</a> to the
-      result of <a for="create a frozen array">creating a frozen array</a> from the result
-      of the <a>convert artwork algorithm</a>.
+      result of [=Create a frozen array|creating a frozen array=] from the result.
     </li>
     <li>
       Return <var>chapterInfo</var>.

--- a/index.bs
+++ b/index.bs
@@ -1381,14 +1381,18 @@ If disabled in the document, the User Agent MUST NOT select the document's media
       title: "Episode Title",
       artist: "Podcast Host",
       album: "Podcast Title",
-      artwork: [{src: "podcast.jpg"}]
+      artwork: [{src: "podcast.jpg"}],
+      chapterInfo: [
+        {title: "Chapter 1", startTime: 0, artwork: [{src: "chapter1.jpg"}]},
+        {title: "Chapter 2", startTime: 120, artwork: [{src: "chapter2.jpg"}]}
+      ]
     });
   </pre>
 
   Alternatively, providing multiple <a for="MediaMetadata" title="artwork
   image">artwork images</a> in the metadata can let the user agent be able to
   select different artwork images for different display purposes and better fit
-  for different screens:
+  for different screens (the same for the artwork in {{MediaMetadata/chapterInfo}}):
 
   <pre class="lang-javascript">
     navigator.mediaSession.metadata = new MediaMetadata({
@@ -1402,6 +1406,16 @@ If disabled in the document, the User Agent MUST NOT select the document's media
         {src: "podcast.png", sizes: "128x128", type: "image/png"},
         {src: "podcast_hd.png", sizes: "256x256", type: "image/png"},
         {src: "podcast.ico", sizes: "128x128 256x256", type: "image/x-icon"}
+      ]
+      chapterInfo: [
+        {title: "Chapter 1", startTime: 0, artwork: [
+           {src: "chapter1_a.jpg", sizes: "128x128", type: "image/jpeg"},
+           {src: "chapter1_b.png", sizes: "256x256", type: "image/png"}
+         ]},
+        {title: "Chapter 2", startTime: 120, artwork: [
+           {src: "chapter2_a.jpg", sizes: "128x128", type: "image/jpeg"},
+           {src: "chapter2_b.png", sizes: "256x256", type: "image/png"}
+         ]}
       ]
     });
   </pre>


### PR DESCRIPTION
Added a `ChapterInformation` attribute in the `MediaMetadata` to carry the Youtube video chapter data:1) title of the section 2)timestamp of this section 3)screenshot image data of this section


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jiajiabingcheng/mediasession/pull/308.html" title="Last updated on Mar 7, 2024, 1:14 AM UTC (dbf1354)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/308/5d4054a...jiajiabingcheng:dbf1354.html" title="Last updated on Mar 7, 2024, 1:14 AM UTC (dbf1354)">Diff</a>