### PR TITLE
Make setMicrophoneActive and setCameraActive return promises.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -85,6 +85,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/dom.html; spec: dom
         text: permissions policy; url:#concept-document-permissions-policy
 urlPrefix: https://www.w3.org/TR/mediacapture-streams/; spec: mediacapture-main
     type: dfn
+        text: MediaStreamTrack; url:#mediastreamtrack
         text: MediaStreamTrack muted state; url:#track-muted
         text: set MediaStreamTrack muted state; url:#set-track-muted
 </pre>
@@ -786,9 +787,9 @@ interface MediaSession {
 
   undefined setPositionState(optional MediaPositionState state = {});
 
-  undefined setMicrophoneActive(boolean active);
+  Promise&lt;undefined&gt; setMicrophoneActive(boolean active);
 
-  undefined setCameraActive(boolean active);
+  Promise&lt;undefined&gt; setCameraActive(boolean active);
 };
 </pre>
 
@@ -922,14 +923,98 @@ interface MediaSession {
 </p>
 
 <p>
-  The <dfn method for=MediaSession>setMicrophoneActive(active)</dfn> and
-  <dfn method for=MediaSession>setCameraActive(active)</dfn> methods indicate to
-  the user agent whether the microphone and camera are currently considered by
-  the page to be active (e.g. if the microphone is considered "muted" by the
-  page since it is no longer sending audio through to a call, then the page can
-  invoke <code>setMicrophoneActive(false)</code>).
-  It is RECOMMENDED that the user agent respect the microphone and camera
-  states indicated by the page in this UI.
+  The <dfn method for=MediaSession>setMicrophoneActive(active)</dfn> method
+  indicates to the user agent the microphone state desired by the page (e.g. if
+  the microphone is considered "muted" by the page since it is no longer sending
+  audio through a call, the page can invoke
+  <code>setMicrophoneActive(false)</code>). When invoked, it MUST perform the
+  following steps:
+  <ul>
+    <li>
+      Let <var>document</var> be [=this=]'s [=relevant global object=]'s
+      [=associated Document=].
+    </li>
+    <li>
+      Let <var>captureKind</var> be "microphone".
+    </li>
+    <li>
+      Return the result of running the [=update capture state algorithm=] with
+      <var>document</var>, <var>active</var> and <var>captureKind</var>.
+    </li>
+  </ul>
+</p>
+<p>
+  Similarly, the <dfn method for=MediaSession>setCameraActive(active)</dfn>
+  method indicates to the user agent the camera state desired by the page. When
+  invoked, it MUST perform the following steps:
+  <ul>
+    <li>
+      Let <var>document</var> be [=this=]'s [=relevant global object=]'s
+      [=associated Document=].
+    </li>
+    <li>
+      Let <var>captureKind</var> be "camera".
+    </li>
+    <li>
+      Return the result of running the [=update capture state algorithm=] with
+      <var>document</var>, <var>active</var> and <var>captureKind</var>.
+    </li>
+  </ul>
+</p>
+<p>
+  When the <dfn>update capture state algorithm</dfn> is invoked with
+  <var>document</var>, <var>active</var> and <var>captureKind</var>, the user
+  agent MUST perform the following steps:
+  <ul>
+    <li>
+      If <var>document</var> is not [=fully active=], return [=a promise
+      rejected with=] <a exception>InvalidStateError</a>.
+    </li>
+    <li>
+      If <var>active</var> is <code>true</code> and <var>document</var>'s
+      [=Document/visibility state=] is not "visible", the user agent MAY return
+      [=a promise rejected with=] <a exception>InvalidStateError</a>.
+    </li>
+    <li>
+      Let <var>p</var> be a new promise.
+    </li>
+    <li>
+      <a>In parallel</a>, run the following substeps::
+      <ul>
+        <li>The user agent MAY wait to proceed, for instance if
+        <var>active</var> is <code>true</code> and <var>document</var>'s
+        [=Document/visibility state=] is not "visible".</li>
+        <li>If <var>active</var> corresponds to <var>captureKind</var>'s state,
+        resolve <var>p</var> with <code>undefined</code> and abort these
+        steps.</li>
+        <li>If the user agent denies the request to change
+        <var>captureKind</var>'s state to <var>active</var>, reject <var>p</var>
+        with a <a exception>NotAllowedError</a> and abort these steps.</li>
+        <li>Let <var>newMutedState</var> be <code>true</code> if
+        <var>active</var> is <code> false</code> and <code>false</code>
+        otherwise.</li>
+        <li>It is recommended that the user agent initiates a change to
+        <var>captureKind</var>'s [=MediaStreamTrack muted state|muted state=]
+        according <var>active</var>. When doing so, the user agent MUST <a>queue
+        a task</a> for any affected [=MediaStreamTrack=] to [=set
+        MediaStreamTrack muted state=] to <var>newMutedState</var>.</li>
+        <li>Update the user agent <var>captureKind</var>'s state UI according
+        <var>active</var>.</li>
+        <li>Resolve <var>p</var> with <code>undefined</code>.</li>
+      </ul>
+    </li>
+    <li>
+      Return <var>p</var>.
+    </li>
+  </ul>
+</p>
+<p class=note>
+  Both the <a>setMicrophoneActive(active)</a> and <a>setCameraActive(active)</a>
+  methods can reject based on user agent specific heuristics. This might in
+  particular happen when the web page asks to activate (aka unmute) microphone
+  or camera. The user agent could decide to require [=transient activation=] in
+  that case. It might also require user input through a prompt to make the
+  actual decision.
 </p>
 
 <p>

--- a/index.bs
+++ b/index.bs
@@ -982,9 +982,13 @@ interface MediaSession {
       <a>In parallel</a>, run the following steps:
       <ol>
         <li>
-          If the user agent implements a policy of <dfn>pausing all
-          input sources</dfn> of type <var>captureKind</var> in response to
-          UI, the user agent SHOULD run the following substeps:
+          Let <var>applyPausePolicy</var> be <code>true</code> if the user agent
+          implements a policy of <dfn>pausing all input sources</dfn> of type
+          <var>captureKind</var> in response to UI and <code>false</code>
+          otherwise.
+        </li>
+        <li>
+          If <var>applyPausePolicy</var> is <code>true</code>, run the following substeps:
           <ol>
             <li>
               Let <var>currentlyActive</var> be <code>false</code> if the user
@@ -1004,6 +1008,16 @@ interface MediaSession {
               reject <var>p</var> with a <a exception>NotAllowedError</a> and
               abort these steps.
             </li>
+          </ol>
+        </li>
+        <li>
+          Update the user agent capture state UI according to <var>captureKind</var>
+          and <var>active</var>.
+        </li>
+        <li>Resolve <var>p</var> with <code>undefined</code>.</li>
+        <li>
+          If <var>applyPausePolicy</var> is <code>true</code>, run the following substeps:
+          <ol>
             <li>
               Let <var>newMutedState</var> be <code>true</code> if <var>active</var> is
               <code>false</code> and <code>false</code> otherwise.</li>
@@ -1014,11 +1028,6 @@ interface MediaSession {
             </li>
           </ol>
         </li>
-        <li>
-          Update the user agent capture state UI according to <var>captureKind</var>
-          and <var>active</var>.
-        </li>
-        <li>Resolve <var>p</var> with <code>undefined</code>.</li>
       </ol>
     </li>
     <li>

--- a/index.bs
+++ b/index.bs
@@ -925,21 +925,21 @@ interface MediaSession {
 <p>
   The <dfn method for=MediaSession>setMicrophoneActive(active)</dfn> method
   indicates to the user agent the microphone state desired by the page (e.g. if
-  the microphone is considered "muted" by the page since it is no longer sending
-  audio through a call, the page can invoke
-  <code>setMicrophoneActive(false)</code>). When invoked, the method MUST perform the
-  following steps:
+  the microphone is considered "inactive" by the page since it is no longer
+  sending audio through a call, the page can invoke
+  <code>setMicrophoneActive(false)</code>). When invoked, the method MUST
+  perform the following steps:
   <ul>
     <li>
       Let <var>document</var> be [=this=]'s [=relevant global object=]'s
       [=associated Document=].
     </li>
     <li>
-      Let <var>captureKind</var> be "microphone".
+      Let <var>captureState</var> be user agent microphone capture state.
     </li>
     <li>
       Return the result of running the [=update capture state algorithm=] with
-      <var>document</var>, <var>active</var> and <var>captureKind</var>.
+      <var>document</var>, <var>active</var> and <var>captureState</var>.
     </li>
   </ul>
 </p>
@@ -953,17 +953,17 @@ interface MediaSession {
       [=associated Document=].
     </li>
     <li>
-      Let <var>captureKind</var> be "camera".
+      Let <var>captureState</var> be user agent camera capture state.
     </li>
     <li>
       Return the result of running the [=update capture state algorithm=] with
-      <var>document</var>, <var>active</var> and <var>captureKind</var>.
+      <var>document</var>, <var>active</var> and <var>captureState</var>.
     </li>
   </ul>
 </p>
 <p>
   When the <dfn>update capture state algorithm</dfn> is invoked with
-  <var>document</var>, <var>active</var> and <var>captureKind</var>, the user
+  <var>document</var>, <var>active</var> and <var>captureState</var>, the user
   agent MUST perform the following steps:
   <ul>
     <li>
@@ -981,24 +981,23 @@ interface MediaSession {
     <li>
       <a>In parallel</a>, run the following substeps:
       <ul>
-       <li>If <var>active</var> is <code>true</code>, the
-       user agent MAY wait to proceed, for instance to        
-       prompt the user.</li>
-        <li>If <var>active</var> corresponds to <var>captureKind</var>'s state,
-        resolve <var>p</var> with <code>undefined</code> and abort these
-        steps.</li>
+        <li>If <var>active</var> is <code>true</code>, the user agent MAY wait
+        to proceed, for instance to prompt the user.</li>
+        <li>If <var>active</var> corresponds to <var>captureState</var>, resolve
+        <var>p</var> with <code>undefined</code> and abort these steps.</li>
         <li>If the user agent denies the request to change
-        <var>captureKind</var>'s state to <var>active</var>, reject <var>p</var>
-        with a <a exception>NotAllowedError</a> and abort these steps.</li>
+        <var>captureState</var> to <var>active</var>, reject <var>p</var> with a
+        <a exception>NotAllowedError</a> and abort these steps.</li>
         <li>Let <var>newMutedState</var> be <code>true</code> if
         <var>active</var> is <code> false</code> and <code>false</code>
         otherwise.</li>
         <li>It is recommended that the user agent initiates a change to
-        <var>captureKind</var>'s [=MediaStreamTrack muted state|muted state=]
-        according <var>active</var>. When doing so, the user agent MUST <a>queue
-        a task</a> for any affected [=MediaStreamTrack=] to [=set
-        MediaStreamTrack muted state=] to <var>newMutedState</var>.</li>
-        <li>Update the user agent <var>captureKind</var>'s state UI according
+        [=MediaStreamTrack muted state|muted state=] for all tracks related to
+        <var>captureState</var> according <var>active</var>. When doing so, the
+        user agent MUST <a>queue a task</a> for any affected
+        [=MediaStreamTrack=] to [=set MediaStreamTrack muted state=] to
+        <var>newMutedState</var>.</li>
+        <li>Update the user agent <var>captureState</var> and UI according
         <var>active</var>.</li>
         <li>Resolve <var>p</var> with <code>undefined</code>.</li>
       </ul>

--- a/index.bs
+++ b/index.bs
@@ -927,7 +927,7 @@ interface MediaSession {
   indicates to the user agent the microphone state desired by the page (e.g. if
   the microphone is considered "muted" by the page since it is no longer sending
   audio through a call, the page can invoke
-  <code>setMicrophoneActive(false)</code>). When invoked, it MUST perform the
+  <code>setMicrophoneActive(false)</code>). When invoked, the method MUST perform the
   following steps:
   <ul>
     <li>

--- a/index.bs
+++ b/index.bs
@@ -979,7 +979,7 @@ interface MediaSession {
       Let <var>p</var> be a new promise.
     </li>
     <li>
-      <a>In parallel</a>, run the following substeps::
+      <a>In parallel</a>, run the following substeps:
       <ul>
         <li>The user agent MAY wait to proceed, for instance if
         <var>active</var> is <code>true</code> and <var>document</var>'s

--- a/index.bs
+++ b/index.bs
@@ -924,48 +924,48 @@ interface MediaSession {
 
 <p>
   The <dfn method for=MediaSession>setMicrophoneActive(active)</dfn> method
-  indicates to the user agent the microphone state desired by the page (e.g. if
-  the microphone is considered "inactive" by the page since it is no longer
-  sending audio through a call, the page can invoke
-  <code>setMicrophoneActive(false)</code>). When invoked, the method MUST
-  perform the following steps:
-  <ul>
+  indicates to the user agent the microphone capture state desired by the page
+  (e.g. if the microphone is considered "inactive" by the page since it is no
+  longer sending audio through a call, the page can invoke
+  <code>setMicrophoneActive(false)</code>). When invoked, it MUST perform
+  the following steps:
+  <ol>
     <li>
       Let <var>document</var> be [=this=]'s [=relevant global object=]'s
       [=associated Document=].
     </li>
     <li>
-      Let <var>captureState</var> be user agent microphone capture state.
+      Let <var>captureKind</var> be "microphone".
     </li>
     <li>
       Return the result of running the [=update capture state algorithm=] with
-      <var>document</var>, <var>active</var> and <var>captureState</var>.
+      <var>document</var>, <var>active</var> and <var>captureKind</var>.
     </li>
-  </ul>
+  </ol>
 </p>
 <p>
   Similarly, the <dfn method for=MediaSession>setCameraActive(active)</dfn>
-  method indicates to the user agent the camera state desired by the page. When
-  invoked, it MUST perform the following steps:
-  <ul>
+  method indicates to the user agent the camera capture state desired by the page.
+  When invoked, it MUST perform the following steps:
+  <ol>
     <li>
       Let <var>document</var> be [=this=]'s [=relevant global object=]'s
       [=associated Document=].
     </li>
     <li>
-      Let <var>captureState</var> be user agent camera capture state.
+      Let <var>captureKind</var> be "camera".
     </li>
     <li>
       Return the result of running the [=update capture state algorithm=] with
-      <var>document</var>, <var>active</var> and <var>captureState</var>.
+      <var>document</var>, <var>active</var> and <var>captureKind</var>.
     </li>
-  </ul>
+  </ol>
 </p>
 <p>
-  When the <dfn>update capture state algorithm</dfn> is invoked with
-  <var>document</var>, <var>active</var> and <var>captureState</var>, the user
-  agent MUST perform the following steps:
-  <ul>
+  The <dfn>update capture state algorithm</dfn>, when invoked with
+  <var>document</var>, <var>active</var> and <var>captureKind</var>,
+  MUST perform the following steps:
+  <ol>
     <li>
       If <var>document</var> is not [=fully active=], return [=a promise
       rejected with=] <a exception>InvalidStateError</a>.
@@ -979,33 +979,52 @@ interface MediaSession {
       Let <var>p</var> be a new promise.
     </li>
     <li>
-      <a>In parallel</a>, run the following substeps:
-      <ul>
-        <li>If <var>active</var> is <code>true</code>, the user agent MAY wait
-        to proceed, for instance to prompt the user.</li>
-        <li>If <var>active</var> corresponds to <var>captureState</var>, resolve
-        <var>p</var> with <code>undefined</code> and abort these steps.</li>
-        <li>If the user agent denies the request to change
-        <var>captureState</var> to <var>active</var>, reject <var>p</var> with a
-        <a exception>NotAllowedError</a> and abort these steps.</li>
-        <li>Let <var>newMutedState</var> be <code>true</code> if
-        <var>active</var> is <code> false</code> and <code>false</code>
-        otherwise.</li>
-        <li>It is recommended that the user agent initiates a change to
-        [=MediaStreamTrack muted state|muted state=] for all tracks related to
-        <var>captureState</var> according <var>active</var>. When doing so, the
-        user agent MUST <a>queue a task</a> for any affected
-        [=MediaStreamTrack=] to [=set MediaStreamTrack muted state=] to
-        <var>newMutedState</var>.</li>
-        <li>Update the user agent <var>captureState</var> and UI according
-        <var>active</var>.</li>
+      <a>In parallel</a>, run the following steps:
+      <ol>
+        <li>
+          If the user agent implements a policy of <dfn>pausing all
+          input sources</dfn> of type <var>captureKind</var> in response to
+          UI, the user agent SHOULD run the following substeps:
+          <ol>
+            <li>
+              Let <var>currentlyActive</var> be <code>false</code> if the user
+              agent is currently [=pausing all input sources=] of type <var>captureKind</var>
+              and <code>true</code> otherwise.
+            </li>
+            <li>
+              If <var>active</var> is <var>currentlyActive</var>, resolve
+              <var>p</var> with <code>undefined</code> and abort these steps.
+            </li>
+            <li>
+              If <var>active</var> is <code>true</code>, the user agent MAY wait to
+              proceed, for instance to prompt the user.
+            </li>
+            <li>
+              If the user agent denies the request to update the capture state,
+              reject <var>p</var> with a <a exception>NotAllowedError</a> and
+              abort these steps.
+            </li>
+            <li>
+              Let <var>newMutedState</var> be <code>true</code> if <var>active</var> is
+              <code>false</code> and <code>false</code> otherwise.</li>
+            <li>
+              For each [=MediaStreamTrack=] whose source is of type <var>captureKind</var>,
+              <a>queue a task</a> to [=set MediaStreamTrack muted state=] to
+              <var>newMutedState</var>.
+            </li>
+          </ol>
+        </li>
+        <li>
+          Update the user agent capture state UI according to <var>captureKind</var>
+          and <var>active</var>.
+        </li>
         <li>Resolve <var>p</var> with <code>undefined</code>.</li>
-      </ul>
+      </ol>
     </li>
     <li>
       Return <var>p</var>.
     </li>
-  </ul>
+  </ol>
 </p>
 <p class=note>
   Both the <a>setMicrophoneActive(active)</a> and <a>setCameraActive(active)</a>

--- a/index.bs
+++ b/index.bs
@@ -981,9 +981,9 @@ interface MediaSession {
     <li>
       <a>In parallel</a>, run the following substeps:
       <ul>
-        <li>The user agent MAY wait to proceed, for instance if
-        <var>active</var> is <code>true</code> and <var>document</var>'s
-        [=Document/visibility state=] is not "visible".</li>
+       <li>If <var>active</var> is <code>true</code>, the
+       user agent MAY wait to proceed, for instance to        
+       prompt the user.</li>
         <li>If <var>active</var> corresponds to <var>captureKind</var>'s state,
         resolve <var>p</var> with <code>undefined</code> and abort these
         steps.</li>


### PR DESCRIPTION
Define steps for each of these methods.
Mention the possibility to mute/unmute tracks based on setMicrophoneActive/setCameraActive calls. Mention the possibility for the user agent to deny the mutation of capture states via setMicrophoneActive/setCameraActive calls.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediasession/pull/312.html" title="Last updated on Feb 14, 2024, 8:23 AM UTC (3cf4e75)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/312/061778a...youennf:3cf4e75.html" title="Last updated on Feb 14, 2024, 8:23 AM UTC (3cf4e75)">Diff</a>