### PR TITLE
Add voiceactivity action.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -412,6 +412,11 @@ platform UI or media keys, thereby improving the user experience.
           the action's intent is to open the media session in a
           picture-in-picture window.
         </li>
+        <li>
+          <dfn enum-value for=MediaSessionAction>voiceactivity</dfn>:
+          the action's intent is to notify the action handler that a voice
+          activity is started.
+        </li>
       </ul>
     </p>
 
@@ -540,6 +545,17 @@ platform UI or media keys, thereby improving the user experience.
       case, the user agent MUST execute the corresponding
       {{MediaSessionActionHandler}} before running, as different tasks, the
       steps defined to [$set a track's muted state$].
+    </p>
+    <p>
+      A user agent MUST invoke {{MediaSessionActionHandler}} for
+      {{MediaSessionAction/voiceactivity}} only when the voice activity is
+      detected from a source with one or more live {{MediaStreamTrack}}s. A user
+      agent MAY ignore a {{MediaSessionAction/voiceactivity}} action if all
+      {{MediaStreamTrack}}s associated with the source are not
+      {{MediaStreamTrack/muted}}. It is RECOMMENDED for user agents to set a
+      minimal interval for invoking {{MediaSessionActionHandler}} for
+      {{MediaSessionAction/voiceactivity}} based on privacy and power efficiency
+      policies.
     </p>
 
     <p class=note>
@@ -716,7 +732,8 @@ enum MediaSessionAction {
   "hangup",
   "previousslide",
   "nextslide",
-  "enterpictureinpicture"
+  "enterpictureinpicture",
+  "voiceactivity"
 };
 
 callback MediaSessionActionHandler = undefined(MediaSessionActionDetails details);
@@ -1496,6 +1513,7 @@ parameter whose dictionary type is:
   <li>{{MediaSessionActionDetails}} for {{MediaSessionAction/nextslide}}.</li>
   <li>{{MediaSessionActionDetails}} for
   {{MediaSessionAction/enterpictureinpicture}}.</li>
+  <li>{{MediaSessionActionDetails}} for {{MediaSessionAction/voiceactivity}}.</li>
 </ul>
 
 The <dfn dict-member for="MediaSessionActionDetails">action</dfn>


### PR DESCRIPTION
This change adds support for the voice activity detection (VAD) feature for microphones. It allows applications to show a notification when the user is speaking while the MediaStreamTrack is muted.

Related discussion in mediacapture-extensions spec: [issue](https://github.com/w3c/mediacapture-extensions/issues/145), [pr](https://github.com/w3c/mediacapture-extensions/pull/153), [slide](https://docs.google.com/presentation/d/1JlGvkhLqHHJ12H7sU4t-u8_wC9tRDRf9-eRBKMwNJxQ/edit#slide=id.g2e31f4508cb_0_1)