### PR TITLE
Queue a task before resolving the promise.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1014,7 +1014,10 @@ interface MediaSession {
           <var>captureKind</var>
           and <var>active</var>.
         </li>
-        <li>Resolve <var>p</var> with <code>undefined</code>.</li>
+        <li>
+           <a>Queue a task</a> using the [=user interaction task source=]
+           to resolve <var>p</var> with <code>undefined</code>.
+        </li>
         <li>
           If <var>applyPausePolicy</var> is <code>true</code>, run the following
           substeps:
@@ -1026,8 +1029,8 @@ interface MediaSession {
             <li>
               For each {{MediaStreamTrack}} whose source is of type
               <var>captureKind</var>,
-              <a>queue a task</a> to [$set a track's muted state$] to
-              <var>newMutedState</var>.
+              <a>queue a task</a>using the [=user interaction task source=]
+              to [$set a track's muted state$] to <var>newMutedState</var>.
             </li>
           </ol>
         </li>


### PR DESCRIPTION
Fix https://github.com/w3c/mediasession/issues/339.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediasession/pull/341.html" title="Last updated on Sep 26, 2024, 5:29 PM UTC (ee415cf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/341/0f6e693...youennf:ee415cf.html" title="Last updated on Sep 26, 2024, 5:29 PM UTC (ee415cf)">Diff</a>