### PR TITLE
Update type of MediaMetadata's artwork

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1095,9 +1095,10 @@ dictionary MediaMetadataInit {
 </p>
 
 <p>
-  A {{MediaMetadata}} has an associated sequence of <dfn for="MediaMetadata">artwork
-  images</dfn>, which is a sequence of type {{MediaImage}}.
-  A {{MediaMetadata}} also has has an associated <dfn for="MediaMetadata">
+  A {{MediaMetadata}} has an associated sequence of <dfn
+  for="MediaMetadata">artwork images</dfn>, which is a sequence of type
+  {{MediaImage}}. A {{MediaMetadata}} also has has an associated <dfn
+  for="MediaMetadata">
   converted artwork images</dfn> which is initially <code>undefined</code>.
 </p>
 
@@ -1167,8 +1168,8 @@ dictionary MediaMetadataInit {
 </p>
 
 When the <dfn>convert artwork algorithm</dfn> with <var>input</var> parameter is
-invoked, where the <var>input</var> is a sequence of type {{MediaImage}},
-the user agent MUST run the following steps:
+invoked, where the <var>input</var> is a sequence of type {{MediaImage}}, the
+user agent MUST run the following steps:
 <ol>
   <li>
     Let <var>output</var> be an empty list of type {{MediaImage}}.
@@ -1234,8 +1235,8 @@ the user agent MUST run the following steps:
   images</a>. On getting, it MUST run the following steps:
   <ol>
     <li>
-      If the {{MediaMetadata}}'s <dfn>converted artwork images</dfn> is <code>undefined</code>,
-      run the following steps:
+      If the {{MediaMetadata}}'s <dfn>converted artwork images</dfn> is
+      <code>undefined</code>, run the following steps:
       <ol>
         <li>
           Let <var>frozenArtwork</var> be a Javascript Array value.
@@ -1245,10 +1246,12 @@ the user agent MUST run the following steps:
           for="MediaMetadata">artwork images</a>, perform the following steps:
           <ol>
             <li>
-              Convert <var>entry</var> into a Javascript object named <var>image</var>.
+              Convert <var>entry</var> into a Javascript object named
+              <var>image</var>.
             </li>
             <li>
-              Perform [=!=] <a abstract-op>SetIntegrityLevel</a>(<var>image</var>,
+              Perform [=!=] <a
+              abstract-op>SetIntegrityLevel</a>(<var>image</var>,
               "<code>frozen</code>"), to prevent accidental mutation by scripts.
             </li>
             <li>
@@ -1257,10 +1260,13 @@ the user agent MUST run the following steps:
           </ol>
         </li>
         <li>
-          Perform [=!=] <a abstract-op>SetIntegrityLevel</a>(<var>frozenArtwork</var>, "<code>frozen</code>").
+          Perform [=!=] <a
+          abstract-op>SetIntegrityLevel</a>(<var>frozenArtwork</var>,
+          "<code>frozen</code>").
         </li>
         <li>
-          Set the {{MediaMetadata}}'s <a>converted artwork images</a> to <var>frozenArtwork</var>.
+          Set the {{MediaMetadata}}'s <a>converted artwork images</a> to
+          <var>frozenArtwork</var>.
         </li>
       </ol>
     </li>
@@ -1271,8 +1277,8 @@ the user agent MUST run the following steps:
   On setting, it MUST run the following steps:
   <ol>
     <li>
-      Let <var>convertedArtwork</var> be the result of converting
-      the new value <var>input</var> into a sequence of type {{MediaImage}}.
+      Let <var>convertedArtwork</var> be the result of converting the new value
+      <var>input</var> into a sequence of type {{MediaImage}}.
     </li>
     <li>
       Run <a>convert artwork algorithm</a> with the converted sequence as
@@ -1280,7 +1286,8 @@ the user agent MUST run the following steps:
       <a for="MediaMetadata">artwork images</a> as the result if it succeeds.
     </li>
     <li>
-      Set the {{MediaMetadata}}'s <a>converted artwork images</a> to <code>undefined</code>.
+      Set the {{MediaMetadata}}'s <a>converted artwork images</a> to
+      <code>undefined</code>.
     </li>
   </ol>
 </p>
@@ -1384,7 +1391,7 @@ dictionary ChapterInformationInit {
     </li>
     <li>
       Set <var>chapterInfo</var>'s <a for="ChapterInformation">artwork
-      images</a> be the result of [=Create a frozen array|creating a frozen
+      images</a> to the result of [=Create a frozen array|creating a frozen
       array=] from {{ChapterInformationInit/artwork}}.
     </li>
     <li>

--- a/index.bs
+++ b/index.bs
@@ -1095,7 +1095,7 @@ dictionary MediaMetadataInit {
 
 <p>
   A {{MediaMetadata}} has an associated list of <dfn for="MediaMetadata">artwork
-  images</dfn> which is a list of type <a idl>object</a> on the interface
+  images</dfn>, which is a list of type <a idl>object</a> on the interface
   but a list of type {{MediaImage}} internally.
 </p>
 

--- a/index.bs
+++ b/index.bs
@@ -1235,19 +1235,19 @@ user agent MUST run the following steps:
   images</a>. On getting, it MUST run the following steps:
   <ol>
     <li>
-      If the {{MediaMetadata}}'s <dfn>converted artwork images</dfn> is
+      If the {{MediaMetadata}}'s <a>converted artwork images</a> is
       <code>undefined</code>, run the following steps:
       <ol>
         <li>
-          Let <var>frozenArtwork</var> be a Javascript Array value.
+          Let <var>frozenArtwork</var> be a JavaScript Array value.
         </li>
         <li>
           For each <var>entry</var> in the {{MediaMetadata}}'s <a
           for="MediaMetadata">artwork images</a>, perform the following steps:
           <ol>
             <li>
-              Convert <var>entry</var> into a Javascript object named
-              <var>image</var>.
+              Let <var>image</var> be the result of [=converted to a JavaScript
+              value|converting to a JavaScript object=] <var>entry</var>.
             </li>
             <li>
               Perform [=!=] <a
@@ -1274,16 +1274,17 @@ user agent MUST run the following steps:
       Return the {{MediaMetadata}}'s <a>converted artwork images</a>.
     </li>
   </ol>
-  On setting, it MUST run the following steps:
+  On setting, it MUST run the following steps with <var>value</var> being the
+  new value being set:
   <ol>
     <li>
-      Let <var>convertedArtwork</var> be the result of converting the new value
-      <var>input</var> into a sequence of type {{MediaImage}}.
+      Let <var>convertedArtwork</var> be the result of [=converted to an IDL
+      value|converting=] <var>value</var> to a sequence of type {{MediaImage}}.
     </li>
     <li>
-      Run <a>convert artwork algorithm</a> with the converted sequence as
-      <var>input</var>, and set the {{MediaMetadata}}'s
-      <a for="MediaMetadata">artwork images</a> as the result if it succeeds.
+      Run <a>convert artwork algorithm</a> with <var>convertedArtwork</var>, and
+      set the {{MediaMetadata}}'s <a for="MediaMetadata">artwork images</a> as
+      the result if it succeeds.
     </li>
     <li>
       Set the {{MediaMetadata}}'s <a>converted artwork images</a> to

--- a/index.bs
+++ b/index.bs
@@ -1063,7 +1063,7 @@ interface MediaMetadata {
   attribute DOMString title;
   attribute DOMString artist;
   attribute DOMString album;
-  attribute FrozenArray&lt;MediaImage> artwork;
+  attribute FrozenArray&lt;object> artwork;
   [SameObject] readonly attribute FrozenArray&lt;ChapterInformation> chapterInfo;
 };
 
@@ -1095,7 +1095,8 @@ dictionary MediaMetadataInit {
 
 <p>
   A {{MediaMetadata}} has an associated list of <dfn for="MediaMetadata">artwork
-  images</dfn>.
+  images</dfn> which is a list of type <a idl>object</a> on the interface
+  but a list of type {{MediaImage}} internally.
 </p>
 
 <p>
@@ -1139,9 +1140,10 @@ dictionary MediaMetadataInit {
     </li>
     <li>
       Run the <a>convert artwork algorithm</a> with <var>init</var>'s
-      {{MediaMetadataInit/artwork}} as <var>input</var> and set
-      <var>metadata</var>'s <a for="MediaMetadata">artwork images</a> as the
-      result if it succeeded.
+      {{MediaMetadataInit/artwork}} as <var>input</var>,
+      where the <var>input</var> is a list of type {{MediaImage}},
+      and set <var>metadata</var>'s <a for="MediaMetadata">artwork images</a>
+      as the result if it succeeded.
     </li>
     <li>
       Let <var>chapters</var> be an empty list of type {{ChapterInformation}}.
@@ -1164,7 +1166,8 @@ dictionary MediaMetadataInit {
 </p>
 
 When the <dfn>convert artwork algorithm</dfn> with <var>input</var> parameter is
-invoked, the user agent MUST run the following steps:
+invoked, where the <var>input</var> is a list of type {{MediaImage}},
+the user agent MUST run the following steps:
 <ol>
   <li>
     Let <var>output</var> be an empty list of type {{MediaImage}}.
@@ -1230,7 +1233,7 @@ invoked, the user agent MUST run the following steps:
   images</a>. On getting, it MUST return the result of the following steps:
   <ol>
     <li>
-      Let <var>frozenArtwork</var> be an empty list of type {{MediaImage}}.
+      Let <var>frozenArtwork</var> be an empty list of type <a idl>object</a>.
     </li>
     <li>
       For each <var>entry</var> in the {{MediaMetadata}}'s <a
@@ -1251,6 +1254,10 @@ invoked, the user agent MUST run the following steps:
           Set <var>image</var>'s {{MediaImage/type}} to <var>entry</var>'s
           {{MediaImage/type}}.
         </li>
+        <li>
+          Convert <var>image</var> into an <var>object</var>
+          whose type is <a idl>object</a>.
+        </li>
         <!-- XXX IDL dictionaries are usually returned by value, so don't need
         to be immutable. But FrozenArray reifies the dictionaries to mutable JS
         objects accessed by reference, so we explicitly freeze them. It would be
@@ -1261,7 +1268,7 @@ invoked, the user agent MUST run the following steps:
           mutation by scripts.
         </li>
         <li>
-          Append <var>image</var> to <var>frozenArtwork</var>.
+          Append the <var>object</var> to <var>frozenArtwork</var>.
         </li>
       </ol>
     </li>
@@ -1269,10 +1276,18 @@ invoked, the user agent MUST run the following steps:
       <a>Create a frozen array</a> from <var>frozenArtwork</var>.
     </li>
   </ol>
-  On setting, it MUST run the
-  <a>convert artwork algorithm</a> with the new value as <var>input</var>, and
-  set the {{MediaMetadata}}'s <a for="MediaMetadata">artwork images</a> as the
-  result if it succeeded.
+  On setting, it MUST run the following steps:
+  <ol>
+    <li>
+      Convert the <var>frozenArtwork</var> from a list of type <a idl>object</a>
+      into a list of type {{MediaImage}}.
+    </li>
+    <li>
+      Run <a>convert artwork algorithm</a> with the converted list as
+      <var>input</var>, and set the {{MediaMetadata}}'s
+      <a for="MediaMetadata">artwork images</a> as the result if it succeeded.
+    </li>
+  </ol>
 </p>
 
 <p>

--- a/index.bs
+++ b/index.bs
@@ -50,6 +50,7 @@ table td, table th {
 
 <pre class="link-defaults">
 spec:html; type:element; text:link
+spec:webidl; type:interface; text:object
 </pre>
 
 <pre class="anchors">
@@ -1094,9 +1095,10 @@ dictionary MediaMetadataInit {
 </p>
 
 <p>
-  A {{MediaMetadata}} has an associated list of <dfn for="MediaMetadata">artwork
-  images</dfn>, which is a list of type <a idl>object</a> on the interface
-  but a list of type {{MediaImage}} internally.
+  A {{MediaMetadata}} has an associated sequence of <dfn for="MediaMetadata">artwork
+  images</dfn>, which is a sequence of type {{MediaImage}}.
+  A {{MediaMetadata}} also has has an associated <dfn for="MediaMetadata">
+  converted artwork images</dfn> which is initially <code>undefined</code>.
 </p>
 
 <p>
@@ -1140,10 +1142,9 @@ dictionary MediaMetadataInit {
     </li>
     <li>
       Run the <a>convert artwork algorithm</a> with <var>init</var>'s
-      {{MediaMetadataInit/artwork}} as <var>input</var>,
-      where the <var>input</var> is a list of type {{MediaImage}},
-      and set <var>metadata</var>'s <a for="MediaMetadata">artwork images</a>
-      as the result if it succeeded.
+      {{MediaMetadataInit/artwork}} as <var>input</var> and set
+      <var>metadata</var>'s <a for="MediaMetadata">artwork images</a> as the
+      result if it succeeded.
     </li>
     <li>
       Let <var>chapters</var> be an empty list of type {{ChapterInformation}}.
@@ -1166,7 +1167,7 @@ dictionary MediaMetadataInit {
 </p>
 
 When the <dfn>convert artwork algorithm</dfn> with <var>input</var> parameter is
-invoked, where the <var>input</var> is a list of type {{MediaImage}},
+invoked, where the <var>input</var> is a sequence of type {{MediaImage}},
 the user agent MUST run the following steps:
 <ol>
   <li>
@@ -1230,62 +1231,56 @@ the user agent MUST run the following steps:
 <p>
   The <dfn attribute for="MediaMetadata">artwork</dfn>
   attribute reflects the {{MediaMetadata}}'s <a for="MediaMetadata">artwork
-  images</a>. On getting, it MUST return the result of the following steps:
+  images</a>. On getting, it MUST run the following steps:
   <ol>
     <li>
-      Let <var>frozenArtwork</var> be an empty list of type <a idl>object</a>.
-    </li>
-    <li>
-      For each <var>entry</var> in the {{MediaMetadata}}'s <a
-      for="MediaMetadata">artwork images</a>, perform the following steps:
+      If the {{MediaMetadata}}'s <dfn>converted artwork images</dfn> is <code>undefined</code>,
+      run the following steps:
       <ol>
         <li>
-          Let <var>image</var> be a new {{MediaImage}}.
+          Let <var>frozenArtwork</var> be a Javascript Array value.
         </li>
         <li>
-          Set <var>image</var>'s {{MediaImage/src}} to <var>entry</var>'s
-          {{MediaImage/src}}.
+          For each <var>entry</var> in the {{MediaMetadata}}'s <a
+          for="MediaMetadata">artwork images</a>, perform the following steps:
+          <ol>
+            <li>
+              Convert <var>entry</var> into a Javascript object named <var>image</var>.
+            </li>
+            <li>
+              Perform [=!=] <a abstract-op>SetIntegrityLevel</a>(<var>image</var>,
+              "<code>frozen</code>"), to prevent accidental mutation by scripts.
+            </li>
+            <li>
+              Push <var>image</var> to <var>frozenArtwork</var>.
+            </li>
+          </ol>
         </li>
         <li>
-          Set <var>image</var>'s {{MediaImage/sizes}} to <var>entry</var>'s
-          {{MediaImage/sizes}}.
+          Perform [=!=] <a abstract-op>SetIntegrityLevel</a>(<var>frozenArtwork</var>, "<code>frozen</code>").
         </li>
         <li>
-          Set <var>image</var>'s {{MediaImage/type}} to <var>entry</var>'s
-          {{MediaImage/type}}.
-        </li>
-        <li>
-          Convert <var>image</var> into an <var>object</var>
-          whose type is <a idl>object</a>.
-        </li>
-        <!-- XXX IDL dictionaries are usually returned by value, so don't need
-        to be immutable. But FrozenArray reifies the dictionaries to mutable JS
-        objects accessed by reference, so we explicitly freeze them. It would be
-        better to do this with IDL primitives instead of JS - see
-        https://www.w3.org/Bugs/Public/show_bug.cgi?id=29004 -->
-        <li>
-          Call {{Object/freeze(O)}} on <var>image</var>, to prevent accidental
-          mutation by scripts.
-        </li>
-        <li>
-          Append the <var>object</var> to <var>frozenArtwork</var>.
+          Set the {{MediaMetadata}}'s <a>converted artwork images</a> to <var>frozenArtwork</var>.
         </li>
       </ol>
     </li>
     <li>
-      <a>Create a frozen array</a> from <var>frozenArtwork</var>.
+      Return the {{MediaMetadata}}'s <a>converted artwork images</a>.
     </li>
   </ol>
   On setting, it MUST run the following steps:
   <ol>
     <li>
-      Convert the <var>frozenArtwork</var> from a list of type <a idl>object</a>
-      into a list of type {{MediaImage}}.
+      Let <var>convertedArtwork</var> be the result of converting
+      the new value <var>input</var> into a sequence of type {{MediaImage}}.
     </li>
     <li>
-      Run <a>convert artwork algorithm</a> with the converted list as
+      Run <a>convert artwork algorithm</a> with the converted sequence as
       <var>input</var>, and set the {{MediaMetadata}}'s
-      <a for="MediaMetadata">artwork images</a> as the result if it succeeded.
+      <a for="MediaMetadata">artwork images</a> as the result if it succeeds.
+    </li>
+    <li>
+      Set the {{MediaMetadata}}'s <a>converted artwork images</a> to <code>undefined</code>.
     </li>
   </ol>
 </p>
@@ -1384,11 +1379,12 @@ dictionary ChapterInformationInit {
     </li>
     <li>
       Let {{ChapterInformationInit/artwork}} be the result of running the
-      <a>convert artwork algorithm</a>.
+      <a>convert artwork algorithm</a> with <var>init</var>'s
+      {{ChapterInformation/artwork}} as <var>input</var>.
     </li>
     <li>
       Set <var>chapterInfo</var>'s <a for="ChapterInformation">artwork
-      images</a> to the result of [=Create a frozen array|creating a frozen
+      images</a> be the result of [=Create a frozen array|creating a frozen
       array=] from {{ChapterInformationInit/artwork}}.
     </li>
     <li>


### PR DESCRIPTION
Fixes https://github.com/w3c/mediasession/issues/237

Introduce a slot where we store the FrozenArray so that the getter always returns the same object.
Make sure the slot is reset when the setter is called.

Implement the conversion on setter and on getter.
Based on https://github.com/w3c/mediasession/pull/243 work from @ChunMinChang


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediasession/pull/343.html" title="Last updated on Sep 29, 2024, 7:20 PM UTC (6f5ac63)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/343/0f6e693...youennf:6f5ac63.html" title="Last updated on Sep 29, 2024, 7:20 PM UTC (6f5ac63)">Diff</a>