### PR TITLE
Queue a task before rejecting the promise in the update capture state algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1008,7 +1008,8 @@ interface MediaSession {
             and <code>true</code> otherwise.
           </li>
           <li>
-            If <var>active</var> is <var>currentlyActive</var>, resolve
+            If <var>active</var> is <var>currentlyActive</var>, <a>queue a task</a>
+            using the [=user interaction task source=] to resolve
             <var>p</var> with <code>undefined</code> and abort these steps.
           </li>
           <li>
@@ -1017,6 +1018,7 @@ interface MediaSession {
           </li>
           <li>
             If the user agent denies the request to update the capture state,
+            <a>queue a task</a> using the [=user interaction task source=] to
             reject <var>p</var> with a <a exception>NotAllowedError</a> and
             abort these steps.
           </li>
@@ -1042,7 +1044,7 @@ interface MediaSession {
           <li>
             For each {{MediaStreamTrack}} whose source is of type
             <var>captureKind</var>,
-            <a>queue a task</a>using the [=user interaction task source=]
+            <a>queue a task</a> using the [=user interaction task source=]
             to [$set a track's muted state$] to <var>newMutedState</var>.
           </li>
         </ol>


### PR DESCRIPTION
Fixes https://github.com/w3c/mediasession/issues/339


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediasession/pull/352.html" title="Last updated on Jan 23, 2025, 3:11 PM UTC (f67dfd8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediasession/352/081423d...youennf:f67dfd8.html" title="Last updated on Jan 23, 2025, 3:11 PM UTC (f67dfd8)">Diff</a>