### PR TITLE
Replace api.csswg.org with spec generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ LOCAL_BIKESHED := $(shell command -v bikeshed 2> /dev/null)
 index.html: index.bs
 	./format.py $<
 ifndef LOCAL_BIKESHED
-	curl https://api.csswg.org/bikeshed/ -F file=@$< > $@
+	curl https://www.w3.org/publications/spec-generator/ -F type=bikeshed-spec -F file=@$< > $@
 else
 	bikeshed spec
 endif

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Access to media keys and lock screen UI will only be granted when audio playback
 
 This spec is built using [Bikeshed](https://github.com/tabatkins/bikeshed).
 
-Update `index.bs` and send a Pull Request with your changes. When your Pull Request will be merged, a new `index.html` will be generated. If you want to test locally, you can run `make` to generate `index.html` using [Bikeshed's web interface](https://api.csswg.org/bikeshed/). However, you should not send the `index.html` file in your Pull Request.
+Update `index.bs` and send a Pull Request with your changes. When your Pull Request will be merged, a new `index.html` will be generated. If you want to test locally, you can run `make` to generate `index.html` using [Spec generator](https://www.w3.org/publications/spec-generator/). However, you should not send the `index.html` file in your Pull Request.
 
 To run Bikeshed locally, [install Bikeshed](https://github.com/tabatkins/bikeshed/blob/prespec/docs/install.md) and then run `bikeshed spec` in the working directory.
 


### PR DESCRIPTION
The former Bikeshed service got deprcecated in favor of Spec generator. This adjusts the README and Makefile accordingly.